### PR TITLE
Enable bulk watchlist parsing

### DIFF
--- a/utils/on_message_utils.py
+++ b/utils/on_message_utils.py
@@ -11,6 +11,8 @@ from utils.parsing_utils import (
     parse_embed_message,
     parse_order_message,
 )
+from utils.csv_utils import save_holdings_to_csv
+from utils.watch_utils import parse_bulk_watchlist_message, add_entries_from_message
 from utils.order_exec import schedule_and_execute
 from utils import split_watch_utils
 from utils.sec_policy_fetcher import SECPolicyFetcher
@@ -83,6 +85,12 @@ async def handle_primary_channel(bot, message):
 
     else:
         logger.info("Parsing regular order message.")
+        entries = parse_bulk_watchlist_message(message.content)
+        if entries:
+            count = add_entries_from_message(message.content)
+            await message.channel.send(f"Added {count} tickers to watchlist.")
+            logger.info(f"Added {count} tickers from bulk watchlist message.")
+            return
         parse_order_message(message.content)
 
 


### PR DESCRIPTION
## Summary
- handle multi-line watchlist messages
- parse watchlist entries and update watchlist

## Testing
- `python -m py_compile utils/watch_utils.py utils/on_message_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6843147cd99483299f1fb02ed65b0843