### PR TITLE
Enable bulk watchlist parsing

### DIFF
--- a/utils/on_message_utils.py
+++ b/utils/on_message_utils.py
@@ -11,6 +11,8 @@ from utils.parsing_utils import (
     parse_embed_message,
     parse_order_message,
 )
+from utils.csv_utils import save_holdings_to_csv
+from utils.watch_utils import parse_bulk_watchlist_message, add_entries_from_message
 from utils.order_exec import schedule_and_execute
 from utils import split_watch_utils
 from utils.sec_policy_fetcher import SECPolicyFetcher
@@ -83,6 +85,12 @@ async def handle_primary_channel(bot, message):
 
     else:
         logger.info("Parsing regular order message.")
+        entries = parse_bulk_watchlist_message(message.content)
+        if entries:
+            count = add_entries_from_message(message.content)
+            await message.channel.send(f"Added {count} tickers to watchlist.")
+            logger.info(f"Added {count} tickers from bulk watchlist message.")
+            return
         parse_order_message(message.content)
 
 

--- a/utils/watch_utils.py
+++ b/utils/watch_utils.py
@@ -3,6 +3,7 @@ import csv
 import json
 import logging
 import os
+import re
 from collections import defaultdict
 from datetime import datetime, timedelta
 
@@ -360,3 +361,58 @@ async def send_reminder_message(bot):
         await channel.send(embed=embed)
     else:
         logging.error("Channel not found.")
+
+
+def parse_bulk_watchlist_message(content: str):
+    """Parse lines of the form 'TICKER X-Y (purchase by mm/dd)'.
+
+    Returns a list of tuples: (ticker, date, ratio).
+    """
+    entries = []
+    pattern = re.compile(
+        r"^([A-Za-z]+)\s+(\d+-\d+)\s*\(purchase by\s+(\d{1,2}/\d{1,2})\)",
+        re.IGNORECASE,
+    )
+    for line in content.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        match = pattern.match(line)
+        if match:
+            ticker, ratio, date = match.groups()
+            entries.append((ticker.upper(), date, ratio))
+    return entries
+
+
+async def watch(ctx, *, text: str):
+    """Discord command handler for ``..watch``.
+
+    Supports the traditional format ``..watch TICKER mm/dd [ratio]`` or a
+    multi-line block of entries like ``TICKER 1-10 (purchase by 6/5)``.
+    """
+    entries = parse_bulk_watchlist_message(text)
+    if entries:
+        count = add_entries_from_message(text)
+        await ctx.send(f"Added {count} tickers to watchlist.")
+        return
+
+    parts = text.split()
+    if len(parts) < 2:
+        await ctx.send(
+            "Usage: '..watch TICKER mm/dd [ratio]' or paste multiple lines in the new format."
+        )
+        return
+
+    ticker = parts[0]
+    split_date = parts[1]
+    split_ratio = parts[2] if len(parts) > 2 else None
+    await watch_list_manager.watch_ticker(ctx, ticker, split_date, split_ratio)
+
+
+def add_entries_from_message(content: str) -> int:
+    """Add multiple watchlist entries parsed from a message."""
+    entries = parse_bulk_watchlist_message(content)
+    for ticker, date, ratio in entries:
+        watch_list_manager.add_ticker(ticker, date, ratio)
+    return len(entries)
+


### PR DESCRIPTION
## Summary
- handle multi-line watchlist messages
- parse watchlist entries and update watchlist
- extend ..watch command to support bulk entry format

## Testing
- `python -m py_compile utils/watch_utils.py utils/on_message_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6843147cd99483299f1fb02ed65b0843