### PR TITLE
Improve holdings CSV import

### DIFF
--- a/utils/on_message_utils.py
+++ b/utils/on_message_utils.py
@@ -74,11 +74,19 @@ async def handle_primary_channel(bot, message):
         try:
             embeds = message.embeds
             parsed_holdings = parse_embed_message(embeds)
+
+            if not parsed_holdings:
+                logger.error("Failed to parse embedded holdings")
+                return
+
             for holding in parsed_holdings:
                 holding["Key"] = (
                     f"{holding['broker']}_{holding['group']}_{holding['account']}_{holding['ticker']}"
                 )
-                parse_embed_message(message)
+
+            save_holdings_to_csv(parsed_holdings)
+        except Exception as e:
+            logger.error(f"Failed to parse or save embedded holdings: {e}")
     else:
         logger.info("Parsing regular order message.")
         parse_order_message(message.content)

--- a/utils/parsing_utils.py
+++ b/utils/parsing_utils.py
@@ -19,7 +19,7 @@ from utils.config_utils import (
     DISCORD_PRIMARY_CHANNEL,
     get_account_nickname,
 )
-from utils.csv_utils import save_holdings_to_csv, save_order_to_csv
+from utils.csv_utils import save_order_to_csv
 from utils.excel_utils import update_excel_log
 from utils.sql_utils import insert_order_history
 from utils.utility_utils import debug_order_data, get_last_stock_price
@@ -581,15 +581,9 @@ def parse_embed_message(embeds):
 
     if not parsed_holdings:
         logger.error("No holdings were parsed from the embed message.")
-        return
+        return []
 
-    save_success = save_holdings_to_csv([parsed_holdings])
-
-    # Check if holdings were successfully saved
-    if save_success:
-        logger.info("Holdings have been successfully parsed and saved.")
-    else:
-        logger.error("Failed to save holdings to CSV.")
+    return parsed_holdings
 
 
 def main_embed_message(embed_list):


### PR DESCRIPTION
## Summary
- update `save_holdings_to_csv` to accept holdings as dicts
- document accepted formats in csv_utils
- fix parsing pipeline to return holdings lists and save correctly

## Testing
- `python -m py_compile utils/parsing_utils.py utils/on_message_utils.py utils/csv_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_684c6e6133048329b82fc71fcbccc349