### PR TITLE
Remove redundant timestamp header logic

### DIFF
--- a/automatic-utils/csv_utils.py
+++ b/automatic-utils/csv_utils.py
@@ -1,3 +1,12 @@
+"""Utility helpers for reading and writing CSV trading logs.
+
+This module centralizes all CSV interactions for holdings and order data. It
+provides convenience wrappers for checking ticker activity, persisting parsed
+holdings or orders, and clearing log files.  The constants ``HOLDINGS_HEADERS``
+and ``ORDERS_HEADERS`` define the expected column order for their respective
+logs.
+"""
+
 import asyncio
 import csv
 import logging
@@ -280,9 +289,6 @@ def save_holdings_to_csv(parsed_holdings):
             for holding in existing_holdings
         )
 
-        # Ensure "Timestamp" is part of HOLDINGS_HEADERS
-        if "Timestamp" not in HOLDINGS_HEADERS:
-            HOLDINGS_HEADERS.append("Timestamp")
 
         # Convert parsed_holdings into a list of dictionaries and filter out duplicates
         new_holdings = []

--- a/utils/csv_utils.py
+++ b/utils/csv_utils.py
@@ -1,3 +1,12 @@
+"""Utility helpers for reading and writing CSV trading logs.
+
+This module centralizes all CSV interactions for holdings and order data. It
+provides convenience wrappers for checking ticker activity, persisting parsed
+holdings or orders, and clearing log files.  The constants ``HOLDINGS_HEADERS``
+and ``ORDERS_HEADERS`` define the expected column order for their respective
+logs.
+"""
+
 import asyncio
 import csv
 import logging
@@ -292,9 +301,6 @@ def save_holdings_to_csv(parsed_holdings):
             for holding in existing_holdings
         )
 
-        # Ensure "Timestamp" is part of HOLDINGS_HEADERS
-        if "Timestamp" not in HOLDINGS_HEADERS:
-            HOLDINGS_HEADERS.append("Timestamp")
 
         # Convert parsed_holdings into a list of dictionaries and filter out duplicates
         new_holdings = []


### PR DESCRIPTION
## Summary
- add module descriptions to CSV utility modules
- drop runtime timestamp header insertion logic from CSV helpers

## Testing
- `python -m compileall -q utils/csv_utils.py automatic-utils/csv_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_684d21d83d6083299bc88c43738f5cff