### PR TITLE
Fix Public order parsing

### DIFF
--- a/unittests/csv_utils_test.py
+++ b/unittests/csv_utils_test.py
@@ -1,9 +1,12 @@
 import csv
 import logging
+import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from utils import csv_utils
 
 

--- a/unittests/parsing_utils_test.py
+++ b/unittests/parsing_utils_test.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from utils import parsing_utils
+
+
+def test_public_incomplete_message(monkeypatch):
+    """Public order messages without account info should create temporary orders."""
+    monkeypatch.setattr(
+        parsing_utils,
+        "account_mapping",
+        {"Public": {"4": {"0000": "Test"}}},
+        raising=False,
+    )
+    parsing_utils.incomplete_orders.clear()
+    parsing_utils.parse_order_message("Public 4: selling 0.10937 of VLCN")
+    key = ("VLCN", "0000")
+    assert key in parsing_utils.incomplete_orders
+    order = parsing_utils.incomplete_orders[key]
+    assert order["broker_name"] == "Public"
+    assert order["broker_number"] == "4"
+    assert order["action"] == "sell"
+    assert pytest.approx(order["quantity"]) == 0.10937

--- a/utils/parsing_utils.py
+++ b/utils/parsing_utils.py
@@ -52,7 +52,9 @@ order_patterns = {
         "Schwab": r"(Schwab)\s(\d+)\s(buying|selling)\s(\d+\.?\d*)\s(\w+)\s@\s(market|limit)",
         "Vanguard": r"(Vanguard)\s(\d+)\s(buying|selling)\s(\d+\.?\d*)\s(\w+)\s@\s(market|limit)",
         "Chase": r"(Chase)\s(\d+)\s(buying|selling)\s(\d+\.?\d*)\s(\w+)\s@\s(LIMIT|MARKET)",
-        "Public": r"(buy|sell)\s(\d+\.?\d*)\sof\s(\w+)\sin\s(?:xxxxx|xxxx)?(\d{4}):\s(Success|Failed)",
+        # Matches order notifications that lack account numbers or status lines.
+        # Example: "Public 4: selling 0.5 of ABC".
+        "Public": r"(Public)\s(\d+):\s(selling|buying)\s(\d+\.?\d*)\sof\s(\w+)",
     },
     "verification": {
         "Schwab": r"(Schwab)\s(\d+)\saccount\sxxxx(\d{4}):\sThe\sorder\sverification\swas\ssuccessful",
@@ -116,7 +118,9 @@ def parse_broker_data(
         "complete": {
             "BBAE": (6, 3, 4, 5),
             "Fennel": (6, 3, 4, 5),
-            "Public": (None, 1, 2, 3),
+            # Public messages do not include account numbers in the initial
+            # notification. Groups are: broker, group, action, quantity, ticker.
+            "Public": (None, 3, 4, 5),
             "Robinhood": (6, 3, 4, 5),
             "WELLSFARGO": (3, 4, 5, 6),
             "Fidelity": (3, 4, 5, 6),
@@ -130,7 +134,8 @@ def parse_broker_data(
             "Vanguard": (None, 3, 4, 5),
             "Chase": (None, 3, 4, 5),
             "Tradier": (None, 3, 4, 5),
-            "Public": (2, 3, 4, 5),
+            # Same group layout as the complete pattern but without account data
+            "Public": (None, 3, 4, 5),
         },
         "verification": {
             "Schwab": (3, None, None, None),


### PR DESCRIPTION
## Summary
- parse Public broker notifications without account numbers
- update field mappings for Public
- add regression test for parsing
- fix unit test imports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68518b8aaf108329b29c0dda0a427926