### PR TITLE
Fix top holdings to use latest data

### DIFF
--- a/automatic-utils/csv_utils.py
+++ b/automatic-utils/csv_utils.py
@@ -260,7 +260,8 @@ def save_order_to_csv(order_data):
 
 # ! --- Holdings Management ---
 
-CURRENT_HOLDINGS = load_csv_log(HOLDINGS_LOG_CSV)
+# ``get_top_holdings`` loads holdings from :data:`HOLDINGS_LOG_CSV` on each
+# invocation, so no module-level cache is maintained.
 
 
 def save_holdings_to_csv(parsed_holdings):
@@ -480,9 +481,12 @@ def get_top_holdings(range=3):
     latest_timestamp = None
 
     try:
+        # Reload holdings from disk each call
+        current_holdings = load_csv_log(HOLDINGS_LOG_CSV)
+
         # Filter holdings where Quantity <= 1 and group by broker
         filtered_holdings = []
-        for holding in CURRENT_HOLDINGS:
+        for holding in current_holdings:
             try:
                 quantity = float(holding.get("Quantity", 0))
                 if quantity <= 1:

--- a/unittests/csv_utils_test.py
+++ b/unittests/csv_utils_test.py
@@ -66,3 +66,64 @@ def run_save_holdings(tmp_path, missing_column, caplog):
 def test_missing_columns_warning(tmp_path, caplog, missing):
     messages = run_save_holdings(tmp_path, missing, caplog)
     assert any("missing columns" in m for m in messages)
+
+
+def test_get_top_holdings_refreshes_data(tmp_path):
+    """get_top_holdings should load data from disk each call."""
+    file_path = tmp_path / "holdings.csv"
+    csv_utils.HOLDINGS_LOG_CSV = str(file_path)
+
+    headers = [
+        "Key",
+        "Broker Name",
+        "Broker Number",
+        "Account Number",
+        "Stock",
+        "Quantity",
+        "Price",
+        "Position Value",
+        "Account Total",
+        "Timestamp",
+    ]
+
+    with open(file_path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(headers)
+        writer.writerow(
+            [
+                "k1",
+                "Broker",
+                "1",
+                "A1",
+                "AAA",
+                1,
+                1,
+                1,
+                1,
+                "2020-01-01 00:00:00",
+            ]
+        )
+
+    top, _ = csv_utils.get_top_holdings(2)
+    assert "Broker" in top and any(h["Stock"] == "AAA" for h in top["Broker"])
+
+    with open(file_path, "a", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(
+            [
+                "k2",
+                "Broker",
+                "1",
+                "A1",
+                "BBB",
+                1,
+                5,
+                5,
+                1,
+                "2020-01-02 00:00:00",
+            ]
+        )
+
+    top, _ = csv_utils.get_top_holdings(2)
+    tickers = {h["Stock"] for h in top["Broker"]}
+    assert {"AAA", "BBB"} <= tickers

--- a/utils/csv_utils.py
+++ b/utils/csv_utils.py
@@ -265,7 +265,9 @@ def save_order_to_csv(order_data):
 
 # ! --- Holdings Management ---
 
-CURRENT_HOLDINGS = load_csv_log(HOLDINGS_LOG_CSV)
+# No module-level cache for holdings. ``get_top_holdings`` will load
+# data from :data:`HOLDINGS_LOG_CSV` each time it is invoked to ensure the
+# freshest data is used.
 
 
 def save_holdings_to_csv(parsed_holdings):
@@ -522,9 +524,12 @@ def get_top_holdings(range=3):
     latest_timestamp = None
 
     try:
+        # Reload holdings from disk each call to avoid stale data
+        current_holdings = load_csv_log(HOLDINGS_LOG_CSV)
+
         # Filter holdings where Quantity <= 1 and group by broker
         filtered_holdings = []
-        for holding in CURRENT_HOLDINGS:
+        for holding in current_holdings:
             try:
                 quantity = float(holding.get("Quantity", 0))
                 if quantity <= 1:


### PR DESCRIPTION
## Summary
- refresh holdings data on every `get_top_holdings` call
- document removal of in-memory holdings cache
- test that new data is picked up by `get_top_holdings`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852e2dec1b48329a462ea7243f5c096