### PR TITLE
Add persistent order queue

### DIFF
--- a/RSAssistant.py
+++ b/RSAssistant.py
@@ -1,4 +1,9 @@
 # RSAssistant.py
+"""Discord bot for monitoring reverse splits and scheduling trades.
+
+This module initializes the Discord bot, registers command handlers, and
+manages scheduled orders using a persistent queue.
+"""
 import asyncio
 import csv
 import json
@@ -98,6 +103,38 @@ periodic_task = None
 reminder_scheduler = None
 
 
+async def reschedule_queued_orders():
+    """Reschedule any persisted orders from previous runs."""
+    queue = get_order_queue()
+    if not queue:
+        logger.info("No queued orders to reschedule.")
+        return
+
+    channel = bot.get_channel(DISCORD_PRIMARY_CHANNEL)
+    if not channel:
+        logger.error("Primary channel not found for rescheduling orders.")
+        return
+
+    for order_id, data in queue.items():
+        try:
+            execution_time = datetime.strptime(data["time"], "%Y-%m-%d %H:%M:%S")
+            bot.loop.create_task(
+                schedule_and_execute(
+                    channel,
+                    action=data["action"],
+                    ticker=data["ticker"],
+                    quantity=data["quantity"],
+                    broker=data["broker"],
+                    execution_time=execution_time,
+                    order_id=order_id,
+                    add_to_queue=False,
+                )
+            )
+            logger.info(f"Rescheduled queued order {order_id}")
+        except Exception as exc:
+            logger.error(f"Failed to reschedule order {order_id}: {exc}")
+
+
 @bot.event
 async def on_ready():
     """Triggered when the bot is ready."""
@@ -129,12 +166,11 @@ async def on_ready():
     except (FileNotFoundError, json.JSONDecodeError):
         ready_message = account_setup_message
 
-    # Send ready message to the primary channel
+    # Send ready message with current time and queue size
     if channel:
+        queued = len(get_order_queue())
         await channel.send(
-            f"{ready_message}\nThe time is {now.strftime('%m-%d %H:%M')}"
-            f"Orders Log at {ORDERS_LOG_CSV}"
-            f"Holdings Log at {HOLDINGS_LOG_CSV}"
+            f"{ready_message}\nTime: {now.strftime('%Y-%m-%d %H:%M:%S')} | Queued orders: {queued}"
         )
     else:
         logger.warning(
@@ -169,6 +205,8 @@ async def on_ready():
         logger.info("Scheduled reminders at 8:45 AM and 3:30 PM started.")
     else:
         logger.info("Reminder scheduler already running.")
+
+    await reschedule_queued_orders()
 
 
 async def process_sell_list(bot):
@@ -228,31 +266,19 @@ async def process_order(
         market_open = now.replace(hour=9, minute=30, second=0, microsecond=0)
         market_close = now.replace(hour=16, minute=0, second=0, microsecond=0)
 
-        if market_open <= now <= market_close:
-            execution_time = now
-            logger.info(
-                f"Executing order {action.upper()} {ticker.upper()} now, market is open"
-            )
-            await ctx.send(
-                f"Executing {action.upper()} {ticker.upper()} immediately (market open)."
-            )
-        else:
-            # Market closed, schedule next open
-            execution_time = now
-            if now >= market_close:
-                execution_time = (now + timedelta(days=1)).replace(
+        def next_open(base: datetime) -> datetime:
+            t = base
+            if t >= market_close:
+                t = (t + timedelta(days=1)).replace(
                     hour=9, minute=30, second=0, microsecond=0
                 )
-            elif now < market_open:
-                execution_time = now.replace(hour=9, minute=30, second=0, microsecond=0)
+            elif t < market_open:
+                t = t.replace(hour=9, minute=30, second=0, microsecond=0)
+            while t.weekday() >= 5:
+                t += timedelta(days=1)
+            return t
 
-            # ⏩ SKIP to Monday if Saturday or Sunday
-            while execution_time.weekday() >= 5:
-                execution_time += timedelta(days=1)
-
-            await ctx.send(
-                f"Market closed. Scheduling {action.upper()} {ticker.upper()} for {execution_time.strftime('%A %m/%d %H:%M')}."
-            )
+        if time:
             try:
                 if "/" in time:
                     if " " in time:
@@ -285,11 +311,6 @@ async def process_order(
 
                 if execution_time < now:
                     execution_time += timedelta(days=1)
-
-                # ⏩ Also skip weekends if custom-scheduled
-                while execution_time.weekday() >= 5:
-                    execution_time += timedelta(days=1)
-
             except ValueError as ve:
                 logger.error(
                     f"Invalid time format provided by user: {time}. Error: {ve}"
@@ -298,15 +319,33 @@ async def process_order(
                     "Invalid time format. Use HH:MM, mm/dd, or HH:MM on mm/dd."
                 )
                 return
+            execution_time = next_open(execution_time)
+        else:
+            if market_open <= now <= market_close and now.weekday() < 5:
+                execution_time = now
+            else:
+                execution_time = next_open(now)
 
-        # Now actually schedule the order
-        await schedule_and_execute(
-            ctx,
-            action=action,
-            ticker=ticker,
-            quantity=quantity,
-            broker=broker,
-            execution_time=execution_time,
+        if execution_time == now:
+            await ctx.send(
+                f"Executing {action.upper()} {ticker.upper()} immediately (market open)."
+            )
+        else:
+            await ctx.send(
+                f"Scheduling {action.upper()} {ticker.upper()} for {execution_time.strftime('%A %m/%d %H:%M')}"
+            )
+
+        order_id = f"{ticker.upper()}_{execution_time.strftime('%Y%m%d_%H%M')}_{action.lower()}"
+        bot.loop.create_task(
+            schedule_and_execute(
+                ctx,
+                action=action,
+                ticker=ticker,
+                quantity=quantity,
+                broker=broker,
+                execution_time=execution_time,
+                order_id=order_id,
+            )
         )
         logger.info(
             f"Order scheduled: {action.upper()} {ticker.upper()} {quantity} {broker} at {execution_time}."
@@ -394,6 +433,7 @@ async def send_scheduled_reminder():
         logger.error(
             f"Could not find channel with ID: {DISCORD_PRIMARY_CHANNEL} to send reminder."
         )
+
 
 @bot.command(name="selling", help="View the current sell queue.")
 async def view_sell_list(ctx):

--- a/unittests/order_queue_manager_test.py
+++ b/unittests/order_queue_manager_test.py
@@ -1,0 +1,26 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from utils import order_queue_manager as oqm
+
+
+def test_add_and_remove_order(tmp_path, monkeypatch):
+    queue_file = tmp_path / "order_queue.json"
+    monkeypatch.setattr(oqm, "QUEUE_FILE", queue_file)
+    oqm.clear_order_queue()
+    order_id = "ABC_20240101_0930_buy"
+    data = {
+        "action": "buy",
+        "ticker": "ABC",
+        "quantity": 1,
+        "broker": "all",
+        "time": "2024-01-01 09:30:00",
+    }
+    oqm.add_to_order_queue(order_id, data)
+    queue = oqm.get_order_queue()
+    assert order_id in queue
+    oqm.remove_order(order_id)
+    queue = oqm.get_order_queue()
+    assert order_id not in queue

--- a/utils/autobuy_utils.py
+++ b/utils/autobuy_utils.py
@@ -37,13 +37,17 @@ async def autobuy_ticker(bot, ctx, ticker, quantity=1, broker="all"):
                 f"Market CLOSED - scheduling autobuy for {ticker} at {execution_time}."
             )
 
-        await schedule_and_execute(
-            ctx=ctx,
-            action="buy",
-            ticker=ticker,
-            quantity=quantity,
-            broker=broker,
-            execution_time=execution_time,
+        order_id = f"{ticker.upper()}_{execution_time.strftime('%Y%m%d_%H%M')}_buy"
+        bot.loop.create_task(
+            schedule_and_execute(
+                ctx=ctx,
+                action="buy",
+                ticker=ticker,
+                quantity=quantity,
+                broker=broker,
+                execution_time=execution_time,
+                order_id=order_id,
+            )
         )
 
         confirmation = f"✅ Auto-buy for `{ticker}` scheduled at {execution_time.strftime('%Y-%m-%d %H:%M:%S')}."

--- a/utils/on_message_utils.py
+++ b/utils/on_message_utils.py
@@ -201,13 +201,17 @@ async def attempt_autobuy(bot, channel, ticker, quantity=1):
             hour=9, minute=30, second=0, microsecond=0
         )
 
-    await schedule_and_execute(
-        ctx=channel,
-        action="buy",
-        ticker=ticker,
-        quantity=quantity,
-        broker="all",
-        execution_time=execution_time,
+    order_id = f"{ticker.upper()}_{execution_time.strftime('%Y%m%d_%H%M')}_buy"
+    bot.loop.create_task(
+        schedule_and_execute(
+            ctx=channel,
+            action="buy",
+            ticker=ticker,
+            quantity=quantity,
+            broker="all",
+            execution_time=execution_time,
+            order_id=order_id,
+        )
     )
 
     confirmation = f"✅ Autobuy for `{ticker}` scheduled at {execution_time.strftime('%Y-%m-%d %H:%M:%S')}."

--- a/utils/order_exec.py
+++ b/utils/order_exec.py
@@ -2,14 +2,16 @@
 
 import asyncio
 import logging
-
-logger = logging.getLogger(__name__)
 from datetime import datetime, timedelta
 
 from utils.watch_utils import watch_list_manager
+from utils.order_queue_manager import add_to_order_queue, remove_order
+
+logger = logging.getLogger(__name__)
 
 # Task queue for handling messages
 task_queue = asyncio.Queue()
+
 
 async def processTasks(message):
     """
@@ -21,6 +23,7 @@ async def processTasks(message):
     logger.info(f"Sending message to Discord: {message}")
     # Simulate sending a message to Discord here
     await asyncio.sleep(0.1)  # Mock delay for sending the message
+
 
 def printAndDiscord(message, loop=None):
     """
@@ -36,6 +39,7 @@ def printAndDiscord(message, loop=None):
         if task_queue.qsize() == 1:  # Start processing if the queue is not empty
             asyncio.run_coroutine_threadsafe(processQueue(), loop)
 
+
 async def processQueue():
     """
     Processes all tasks in the queue and sends them to Discord.
@@ -45,23 +49,18 @@ async def processQueue():
         await processTasks(message)
         task_queue.task_done()
 
-async def send_sell_command(ctx, command: str, loop=None):
-    """
-    Sends the `!rsa sell` command to the specified Discord channel using helperAPI.
 
-    Args:
-        ctx (discord.ext.commands.Context): The Discord context object.
-        command (str): The command to send.
-        loop (asyncio.AbstractEventLoop): The event loop for task queue processing.
-    """
+async def send_sell_command(target, command: str, loop=None):
+    """Send an order command to a Discord context or channel."""
+
     try:
-        # Send the command using the helperAPI
         logger.info(f"Preparing to send command: {command}")
-        await ctx.send(command)
-        logger.info(f"Sent command: {command} to channel {ctx.channel.id}")
+        await target.send(command)
+        channel = getattr(target, "channel", target)
+        channel_id = getattr(channel, "id", "unknown")
+        logger.info(f"Sent command: {command} to channel {channel_id}")
     except Exception as e:
         logger.error(f"Error sending sell command: {e}")
-        await ctx.send(command)
 
 
 async def process_sell_list():
@@ -69,7 +68,9 @@ async def process_sell_list():
         try:
             now = datetime.now()
             for ticker, details in list(watch_list_manager.sell_list.items()):
-                scheduled_time = datetime.strptime(details["scheduled_time"], "%Y-%m-%d %H:%M:%S")
+                scheduled_time = datetime.strptime(
+                    details["scheduled_time"], "%Y-%m-%d %H:%M:%S"
+                )
                 if now >= scheduled_time:
                     # Execute the sell command
                     command = f"test command {details['quantity']} {ticker} {details['broker']} false"
@@ -84,41 +85,56 @@ async def process_sell_list():
             logger.error(f"Error processing sell list: {e}")
 
 
+async def schedule_and_execute(
+    ctx,
+    action: str,
+    ticker: str,
+    quantity: float,
+    broker: str,
+    execution_time: datetime,
+    *,
+    order_id: str | None = None,
+    add_to_queue: bool = True,
+):
+    """Schedule and execute an order at ``execution_time``."""
 
-async def schedule_and_execute(ctx, action: str, ticker: str, quantity: float, broker: str, execution_time: datetime):
-    """
-    Schedules and executes a sell order by sending a command to the target bot using helperAPI.
-
-    Args:
-        ctx (discord.ext.commands.Context): The Discord context object.
-        action (str): Order type - buy|sell
-        ticker (str): The stock ticker symbol.
-        quantity (float): Quantity of stock to sell.
-        broker (str): Broker to execute the sell order. Use 'all' for all brokers.
-        execution_time (datetime): The time to execute the sell order.
-    """
     try:
-        # Add order to the sell list
-        watch_list_manager.add_to_sell_list(
-            ticker=ticker,
-            broker=broker,
-            quantity=quantity,
-            scheduled_time=execution_time.strftime("%Y-%m-%d %H:%M:%S"),
-        )
+        if order_id is None:
+            order_id = f"{ticker.upper()}_{execution_time.strftime('%Y%m%d_%H%M')}_{action.lower()}"
 
-        # Calculate delay until execution
+        if add_to_queue:
+            add_to_order_queue(
+                order_id,
+                {
+                    "action": action,
+                    "ticker": ticker.upper(),
+                    "quantity": quantity,
+                    "broker": broker,
+                    "time": execution_time.strftime("%Y-%m-%d %H:%M:%S"),
+                },
+            )
+
+        if action.lower() == "sell":
+            watch_list_manager.add_to_sell_list(
+                ticker=ticker,
+                broker=broker,
+                quantity=quantity,
+                scheduled_time=execution_time.strftime("%Y-%m-%d %H:%M:%S"),
+            )
+
         now = datetime.now()
-        delay = (execution_time - now).total_seconds()
-
+        delay = max((execution_time - now).total_seconds(), 0)
         if delay > 0:
             logger.info(f"Waiting {delay} seconds to execute {action} command.")
             await asyncio.sleep(delay)
 
-        # Construct the command
         command = f"!rsa {action} {quantity} {ticker.upper()} {broker} false"
-
-        # Execute the command
         await send_sell_command(ctx, command, loop=asyncio.get_event_loop())
+
+        if action.lower() == "sell":
+            watch_list_manager.remove_from_sell_list(ticker)
+
+        remove_order(order_id)
 
     except Exception as e:
         logger.error(f"Error in scheduled {action} order execution: {e}")

--- a/utils/order_queue_manager.py
+++ b/utils/order_queue_manager.py
@@ -1,10 +1,16 @@
 # utils/order_queue_manager.py
 
+"""Persistent order queue utilities."""
+
 import json
 import os
+from pathlib import Path
 from datetime import datetime
 
-QUEUE_FILE = "data/order_queue.json"
+from utils.config_utils import VOLUMES_DIR
+
+QUEUE_FILE = VOLUMES_DIR / "db" / "order_queue.json"
+QUEUE_FILE.parent.mkdir(parents=True, exist_ok=True)
 
 
 def _load_queue():


### PR DESCRIPTION
## Summary
- persist queued orders in `volumes/db/order_queue.json`
- schedule queued orders on startup
- refactor order scheduling to store/remove queued orders
- support scheduling in autobuy and message handlers
- improve `..ord` command time parsing
- test order queue persistence
- show the number of queued orders on startup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854aed0a7e083298888703b7baece8d