### PR TITLE
Add owner summary view

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Features
 	•	Dynamic scheduling: handles market open/close, weekends, and holidays.
 	•	Professional-grade logging for full traceability and debugging.
 	•	Seamless Discord integration for alerts, updates, and order confirmations.
+        •       Aggregated owner holdings across brokers via `..ownersummary` command.
 
 ⸻
 

--- a/RSAssistant.py
+++ b/RSAssistant.py
@@ -57,6 +57,7 @@ from utils.utility_utils import (
     all_account_nicknames,
     all_brokers,
     generate_broker_summary_embed,
+    generate_owner_totals_embed,
     print_to_discord,
     track_ticker_summary,
 )
@@ -450,6 +451,16 @@ async def brokers_groups(ctx, broker: str = None):
             embed if embed else "An error occurred while generating the broker summary."
         )
     )
+
+
+@bot.command(
+    name="ownersummary",
+    help="Shows total holdings for each owner across all brokers.",
+)
+async def owner_summary(ctx):
+    """Display aggregated owner holdings across all brokers."""
+    embed = generate_owner_totals_embed()
+    await ctx.send(embed=embed)
 
 
 # Discord bot command

--- a/unittests/utility_utils_test.py
+++ b/unittests/utility_utils_test.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from utils import utility_utils
+
+
+def test_aggregate_owner_totals(monkeypatch):
+    sample = {
+        "Broker1": {"OwnerA": 100.0, "OwnerB": 50.0},
+        "Broker2": {"OwnerA": 25.0, "OwnerB": 25.0, "OwnerC": 10.0},
+    }
+    monkeypatch.setattr(
+        utility_utils,
+        "all_brokers_summary_by_owner",
+        lambda specific_broker=None: sample,
+    )
+
+    totals = utility_utils.aggregate_owner_totals()
+    assert totals == {"OwnerA": 125.0, "OwnerB": 75.0, "OwnerC": 10.0}

--- a/utils/utility_utils.py
+++ b/utils/utility_utils.py
@@ -658,73 +658,65 @@ def all_brokers_summary_by_owner(specific_broker=None):
 
 
 def generate_broker_summary_embed(ctx, specific_broker=None):
-    """
-    Generates a Discord embed for account owner summaries.
+    """Return a Discord embed summarizing holdings by owner for each broker."""
 
-    Parameters:
-        broker_name (str, optional): If provided, only show summary for this broker.
+    brokers_summary = all_brokers_summary_by_owner(specific_broker)
+    broker_label = (
+        specific_broker.upper()
+        if specific_broker and specific_broker.lower() in ["bbae", "dspac"]
+        else specific_broker.capitalize() if specific_broker else "All Active Brokers"
+    )
 
-    Returns:
-        discord.Embed: The generated embed with summaries by account owner.
-    """
-    brokers_summary = all_brokers_summary_by_owner(specific_broker=None)
-    if specific_broker:
-        broker = (
-            specific_broker.upper()
-            if specific_broker.lower() in ["bbae", "dspac"]
-            else specific_broker.capitalize()
-        )
-    else:
-        broker = "All Active Brokers"
+    embed = discord.Embed(title=f"**{broker_label} Summary**", color=discord.Color.blue())
 
-    embed_title = f"**{broker} Summary**"
-    embed = discord.Embed(title=embed_title, color=discord.Color.blue())
-
-    for broker, owner_totals in brokers_summary.items():
-        # Calculate the total number of accounts for the broker
+    for broker_name, owner_totals in brokers_summary.items():
         account_owner_count = sum(
             len(accounts)
-            for broker_number, accounts in ACCOUNT_MAPPING.get(broker, {}).items()
+            for _group, accounts in ACCOUNT_MAPPING.get(broker_name, {}).items()
         )
+        broker_total = sum(owner_totals.values())
 
-        broker_total = sum(
-            owner_totals.values()
-        )  # Calculate the total holdings for the broker
+        filtered_totals = {o: t for o, t in owner_totals.items() if t != 0}
+        if not filtered_totals:
+            continue
 
-        # Include broker total in the summary header
-        broker_summary = (
-            f"({account_owner_count} Owner groups, Total: ${broker_total:,.2f})\n"
+        broker_summary = f"({account_owner_count} Owner groups, Total: ${broker_total:,.2f})\n"
+        for owner, total in filtered_totals.items():
+            broker_summary += f"{owner}: ${total:,.2f}\n"
+
+        formatted_name = (
+            broker_name.upper()
+            if broker_name.lower() in ["bbae", "dspac"]
+            else broker_name.capitalize()
         )
+        embed.add_field(name=formatted_name, value=broker_summary.strip(), inline=True)
 
-        for account_owner, account_totals in owner_totals.items():
-            broker_summary += f"{account_owner}: ${account_totals:,.2f}\n"
+        if specific_broker:
+            break
 
-        # Filter out zero-balance owners
-        filtered_totals = {
-            owner: total for owner, total in owner_totals.items() if total != 0
-        }
+    return embed
 
-        # Only add the broker field if there are owners with non-zero balances
-        if filtered_totals:
-            for owner, total in filtered_totals.items():
-                broker_summary += f"{owner}: ${total:,.2f}\n"
 
-            # Capitalize or adjust broker name if needed
-            formatted_broker_name = (
-                broker.upper()
-                if broker.lower() in ["bbae", "dspac"]
-                else broker.capitalize()
-            )
-            embed.add_field(
-                name=formatted_broker_name,
-                value=broker_summary.strip(),  # Remove trailing newline
-                inline=True,
-            )
+def aggregate_owner_totals():
+    """Return total holdings aggregated by owner across all brokers."""
 
-            # Only show one broker if a specific one was requested
-            if specific_broker:
-                break
+    summary = all_brokers_summary_by_owner()
+    owner_totals = {}
+    for broker_totals in summary.values():
+        for owner, total in broker_totals.items():
+            owner_totals[owner] = owner_totals.get(owner, 0.0) + total
+    return owner_totals
 
+
+def generate_owner_totals_embed():
+    """Create a Discord embed showing aggregated holdings by owner."""
+
+    owner_totals = aggregate_owner_totals()
+    embed = discord.Embed(
+        title="**Owner Totals Across Brokers**", color=discord.Color.blue()
+    )
+    for owner, total in sorted(owner_totals.items(), key=lambda x: x[1], reverse=True):
+        embed.add_field(name=owner, value=f"${total:,.2f}", inline=True)
     return embed
 
 


### PR DESCRIPTION
## Summary
- enable aggregated owner holdings across brokers
- fix passing specific broker to summary logic
- add `ownersummary` bot command
- document the new command
- cover owner totals logic with unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854af2904488329b5ff1ab8a0580432