### PR TITLE
Add persistent price cache

### DIFF
--- a/automatic-utils/utility_utils.py
+++ b/automatic-utils/utility_utils.py
@@ -9,7 +9,8 @@ from pathlib import Path
 
 import discord
 import yaml
-import yfinance as yf
+import yfinance as yf  # Deprecated direct usage
+from utils.yfinance_cache import get_price
 
 from utils.config_utils import (ACCOUNT_MAPPING, 
                                 HOLDINGS_LOG_CSV, ORDERS_LOG_CSV,
@@ -382,17 +383,12 @@ async def all_brokers(ctx):
 
 # Retrieve Last Stock Price
 def get_last_stock_price(stock):
-    """Fetches the last price of a given stock using Yahoo Finance."""
-    try:
-        ticker = yf.Ticker(stock)
-        stock_info = ticker.history(period="1d")
-        if not stock_info.empty:
-            return round(stock_info["Close"].iloc[-1], 2)
+    """Return the cached last price of ``stock`` using :func:`get_price`."""
+
+    price = get_price(stock)
+    if price is None:
         logging.warning(f"No stock data found for {stock}.")
-        return None
-    except Exception as e:
-        logging.error(f"Error fetching last price for {stock}: {e}")
-        return None
+    return price
 
 # -- Get Totals for Specific Broker
 def get_account_totals(broker, group_number=None, account_number=None):

--- a/unittests/yfinance_cache_test.py
+++ b/unittests/yfinance_cache_test.py
@@ -1,0 +1,45 @@
+"""Tests for the persistent Yahoo Finance price cache."""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from utils import yfinance_cache
+
+
+def test_get_price_persists_and_loads(tmp_path, monkeypatch):
+    """`get_price` should persist prices to disk and reload them."""
+
+    cache_file = tmp_path / "prices.json"
+    monkeypatch.setattr(yfinance_cache, "CACHE_FILE", cache_file)
+    monkeypatch.setattr(yfinance_cache, "_CACHE", {})
+    monkeypatch.setattr(yfinance_cache, "_FILE_CACHE_LOADED", False)
+
+    fake_time = 1000
+
+    monkeypatch.setattr(
+        yfinance_cache,
+        "time",
+        SimpleNamespace(time=lambda: fake_time),
+    )
+
+    class DummyTicker:
+        def history(self, period="1d"):
+            return pd.DataFrame({"Close": [10.0]})
+
+    monkeypatch.setattr(yfinance_cache.yf, "Ticker", lambda t: DummyTicker())
+    price = yfinance_cache.get_price("ABC")
+    assert price == 10.0
+    assert cache_file.exists()
+
+    # Clear in-memory cache to force reload from disk
+    monkeypatch.setattr(yfinance_cache, "_CACHE", {})
+    monkeypatch.setattr(yfinance_cache, "_FILE_CACHE_LOADED", False)
+    monkeypatch.setattr(yfinance_cache.yf, "Ticker", lambda t: (_ for _ in ()).throw(AssertionError()))
+
+    price = yfinance_cache.get_price("ABC")
+    assert price == 10.0

--- a/utils/yfinance_cache.py
+++ b/utils/yfinance_cache.py
@@ -1,17 +1,67 @@
+"""Simple Yahoo Finance price cache with optional on-disk persistence."""
+
+from __future__ import annotations
+
+import json
 import logging
 import time
 from typing import Dict, Tuple
 
 import yfinance as yf
 
+from utils.config_utils import VOLUMES_DIR
+
+
 logger = logging.getLogger(__name__)
 
 _CACHE: Dict[str, Tuple[float, float]] = {}
+_FILE_CACHE_LOADED = False
+
+# cache stored under volumes/cache to survive bot restarts
+CACHE_FILE = VOLUMES_DIR / "cache" / "yf_price_cache.json"
 TTL_SECONDS = 600  # 10 minutes
 
 
+def _load_cache_from_file() -> None:
+    """Populate in-memory cache from :data:`CACHE_FILE` if present."""
+
+    global _FILE_CACHE_LOADED
+    if _FILE_CACHE_LOADED or not CACHE_FILE.exists():
+        _FILE_CACHE_LOADED = True
+        return
+
+    try:
+        with open(CACHE_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        for ticker, (ts, price) in data.items():
+            _CACHE[ticker] = (float(ts), float(price))
+        logger.debug("Loaded price cache from %s", CACHE_FILE)
+    except Exception as e:
+        logger.warning("Failed to load price cache: %s", e)
+    finally:
+        _FILE_CACHE_LOADED = True
+
+
+def _save_cache_to_file() -> None:
+    """Persist the in-memory cache to :data:`CACHE_FILE`."""
+
+    try:
+        CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        with open(CACHE_FILE, "w", encoding="utf-8") as f:
+            json.dump(_CACHE, f)
+    except Exception as e:
+        logger.warning("Failed to save price cache: %s", e)
+
+
 def get_price(ticker: str) -> float | None:
+    """Return the latest closing price for ``ticker``.
+
+    The price is cached in-memory and persisted to :data:`CACHE_FILE`. Cached
+    values older than :data:`TTL_SECONDS` are refreshed from Yahoo Finance.
+    """
+
     ticker = ticker.upper().strip()
+    _load_cache_from_file()
     now = time.time()
     if ticker in _CACHE:
         ts, price = _CACHE[ticker]
@@ -22,6 +72,7 @@ def get_price(ticker: str) -> float | None:
         if not data.empty:
             price = round(float(data["Close"].iloc[-1]), 2)
             _CACHE[ticker] = (now, price)
+            _save_cache_to_file()
             return price
         logger.warning("No data returned for %s", ticker)
     except Exception as e:


### PR DESCRIPTION
## Summary
- persist yfinance prices to `volumes/cache/yf_price_cache.json`
- expose helper functions to load/save the cache
- adjust old utility to use cached price function
- add unit test verifying cache persistence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859574a178883299fb1160d9d39abac