### PR TITLE
Handle missing stock prices

### DIFF
--- a/unittests/parsing_utils_test.py
+++ b/unittests/parsing_utils_test.py
@@ -23,3 +23,46 @@ def test_public_incomplete_message(monkeypatch):
     assert order["broker_number"] == "4"
     assert order["action"] == "sell"
     assert pytest.approx(order["quantity"]) == 0.10937
+
+
+def _setup_price_none(monkeypatch, call_tracker):
+    """Helper to patch dependencies when price lookup returns None."""
+
+    monkeypatch.setattr(parsing_utils, "get_last_stock_price", lambda s: None)
+
+    def rec(msg, details):
+        call_tracker["record"] = call_tracker.get("record", 0) + 1
+
+    monkeypatch.setattr(parsing_utils, "record_error_message", rec)
+
+    def csv_save(data):
+        call_tracker["csv"] = call_tracker.get("csv", 0) + 1
+
+    monkeypatch.setattr(parsing_utils, "save_order_to_csv", csv_save)
+    monkeypatch.setattr(parsing_utils, "insert_order_history", lambda *a, **k: None)
+    monkeypatch.setattr(parsing_utils, "update_excel_log", lambda *a, **k: None)
+
+
+def test_handle_complete_order_price_none(monkeypatch):
+    """handle_complete_order should log an error and skip saves when price is None."""
+
+    calls = {}
+    _setup_price_none(monkeypatch, calls)
+
+    parsing_utils.parse_order_message("BBAE 1: buy 1 of ABC in xxxx1234: Success")
+
+    assert calls.get("record", 0) == 1
+    assert calls.get("csv") is None
+
+
+def test_process_verified_orders_price_none(monkeypatch):
+    """process_verified_orders should log an error and skip saves when price is None."""
+
+    calls = {}
+    _setup_price_none(monkeypatch, calls)
+
+    order = {"action": "buy", "quantity": 1, "stock": "ABC"}
+    parsing_utils.process_verified_orders("BBAE", "1", "1234", order)
+
+    assert calls.get("record", 0) == 1
+    assert calls.get("csv") is None


### PR DESCRIPTION
## Summary
- abort order processing when price lookup fails
- log failed price lookups to Excel error log
- test missing price logic in `handle_complete_order` and `process_verified_orders`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c37757bc88329a2f7024f672bdcf6