### PR TITLE
Add default nickname fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Alternatively, build and run with Docker:
 docker compose up --build
 ```
 
+## Default Account Nicknames
+
+When an account has no nickname in `account_mapping.json`, RSAssistant falls
+back to the pattern `"{broker} {group} {account}"`. This ensures new accounts
+and orders are always logged with a deterministic identifier.
+
 ## Testing
 
 Run unit tests with:

--- a/utils/excel_utils.py
+++ b/utils/excel_utils.py
@@ -17,7 +17,7 @@ from utils.config_utils import (
     ERROR_LOG_FILE,
     EXCEL_FILE_MAIN,
     HOLDINGS_LOG_CSV,
-    get_account_nickname,
+    get_account_nickname_or_default,
     load_account_mappings,
     load_config,
 )
@@ -222,9 +222,9 @@ async def index_account_details(
                     )
 
             # Add or update the account details under the broker and group number
-            account_mappings[broker_name][group_number][account_number] = (
-                account_nickname
-            )
+            account_mappings[broker_name][group_number][
+                account_number
+            ] = account_nickname
 
     except Exception as e:
         await ctx.send(f"Error processing Excel rows: {e}")
@@ -618,7 +618,7 @@ def update_excel_log(order_data, order_type=None, filename=BASE_EXCEL_FILE):
             # Log the extracted details
             logger.debug(f"Processing order: {order}")
 
-            account_nickname = get_account_nickname(
+            account_nickname = get_account_nickname_or_default(
                 broker_name, broker_number, account_number
             )
             excel_nickname = f"{broker_name} {account_nickname}"


### PR DESCRIPTION
## Summary
- add `DEFAULT_ACCOUNT_NICKNAME` constant
- update `get_account_nickname` to format fallback
- expose `get_account_nickname_or_default`
- use fallback in Excel and SQL helpers
- document behaviour in README

## Testing
- `black utils/config_utils.py utils/excel_utils.py utils/sql_utils.py`
- `pytest -q` *(fails: SyntaxError in parsing_utils_test.py)*

------
https://chatgpt.com/codex/tasks/task_e_6866f00401ec83299859398f41cb1e70