### PR TITLE
Watchlist audit during refresh

### DIFF
--- a/unittests/on_message_utils_test.py
+++ b/unittests/on_message_utils_test.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from utils.on_message_utils import compute_account_missing_tickers
+from utils.watch_utils import watch_list_manager
+
+
+def test_compute_account_missing_tickers(monkeypatch):
+    monkeypatch.setattr(
+        watch_list_manager,
+        "get_watch_list",
+        lambda: {"AAA": {}, "BBB": {}},
+    )
+    holdings = [
+        {"broker": "Test", "account_name": "Nick1", "account": "1111", "ticker": "AAA"},
+        {"broker": "Test", "account_name": "Nick1", "account": "1111", "ticker": "CCC"},
+        {"broker": "Test", "account_name": "Nick2", "account": "2222", "ticker": "BBB"},
+    ]
+    result = compute_account_missing_tickers(holdings)
+    assert result == {
+        "Test Nick1 (1111)": ["BBB"],
+        "Test Nick2 (2222)": ["AAA"],
+    }


### PR DESCRIPTION
## Summary
- audit missing watchlist tickers while ..all runs
- expose audit helpers in `on_message_utils`
- include missing ticker summary in `..all` command
- add unit test for audit logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d34aef6dc832992b2b22bd8ed0591