### PR TITLE
Fix ..bw alias

### DIFF
--- a/RSAssistant.py
+++ b/RSAssistant.py
@@ -468,9 +468,14 @@ async def brokerlist(ctx, broker: str = None):
 @bot.command(
     name="bw",
     help="Broker-With <ticker> (details) | All brokers with specified ticker, opt details=specific broker",
+    aliases=["brokerwith"],
 )
 async def broker_has(ctx, ticker: str, *args):
-    """Shows broker-level summary for a specific ticker."""
+    """Shows broker-level summary for a specific ticker.
+
+    This command is available as ``..bw`` or ``..brokerwith`` and
+    optionally accepts a broker name to display account-level details.
+    """
     specific_broker = args[0] if args else None
     await track_ticker_summary(
         ctx, ticker, show_details=bool(specific_broker), specific_broker=specific_broker

--- a/unittests/brokerwith_command_test.py
+++ b/unittests/brokerwith_command_test.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import RSAssistant
+
+
+def test_brokerwith_alias():
+    cmd_bw = RSAssistant.bot.get_command("bw")
+    cmd_alias = RSAssistant.bot.get_command("brokerwith")
+    assert cmd_bw is cmd_alias


### PR DESCRIPTION
## Summary
- allow `..brokerwith` alias for the `..bw` command
- document alias in the broker summary command
- add a unit test to ensure alias works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68886cec68088329b193e54dfdbf023b