### PR TITLE
Add configurable volumes directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ RSAssistant is a Discord bot that monitors corporate actions and automates tradi
 - Schedules buy or sell orders and executes them via autoRSA.
 - The `..all` command refreshes holdings, audits them against the watchlist,
   and posts a summary of any missing tickers.
-- Stores logs and a SQLite database under `volumes/` for persistence.
+- Stores logs and a SQLite database under `volumes/` for persistence. Set
+  the `VOLUMES_DIR` environment variable to use a different location (e.g.
+  `/mnt/netstorage/volumes`).
 
 ## Directory Overview
 
@@ -44,6 +46,9 @@ pip install -r requirements.txt
 cp config/example.env volumes/config/.env
 cp config/example.settings.yaml volumes/config/settings.yml
 ```
+
+If you want RSAssistant to store data in an external location, set the
+``VOLUMES_DIR`` variable in ``volumes/config/.env`` to your desired path.
 
 3. Launch the bot:
 

--- a/config/example.env
+++ b/config/example.env
@@ -5,6 +5,10 @@ DISCORD_PRIMARY_CHANNEL=
 # -- Nasdaq Corporate Actions RSS Feed
 DISCORD_SECONDARY_CHANNEL=
 
+# Optional path to the persistent data directory. Defaults to
+# '<repo>/volumes' when unset.
+VOLUMES_DIR=/mnt/netstorage/volumes
+
 # -- Not yet implemented: 
 # MY_ID=
 # AUTO_RSA_BOT=

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,8 +9,11 @@ echo "Initializing RSAssistant environment..."
 # Optionally set the DISPLAY environment variable in development mode
 export DISPLAY=:99
 
+# Determine the volumes directory (default /app/volumes)
+VOLUMES_DIR="${VOLUMES_DIR:-/app/volumes}"
+
 # Check for required directories in volumes and create them if they don't exist
-REQUIRED_DIRECTORIES="/app/volumes/logs /app/volumes/excel /app/volumes/db /app/volumes/config"
+REQUIRED_DIRECTORIES="$VOLUMES_DIR/logs $VOLUMES_DIR/excel $VOLUMES_DIR/db $VOLUMES_DIR/config"
 
 for DIR in $REQUIRED_DIRECTORIES; do
   if [ ! -d "$DIR" ]; then
@@ -20,13 +23,13 @@ for DIR in $REQUIRED_DIRECTORIES; do
 done
 
 # Set permissions to ensure the container user has appropriate access
-chmod -R 755 /app/volumes
+chmod -R 755 "$VOLUMES_DIR"
 
 # Set ownership (if running as a non-root user)
 # chown -R appuser:appuser /app/volumes
 
 # Initialize log files (if necessary)
-LOG_FILE="/app/volumes/logs/rsassistant.log"
+LOG_FILE="$VOLUMES_DIR/logs/rsassistant.log"
 if [ ! -f "$LOG_FILE" ]; then
   echo "Initializing log file: $LOG_FILE"
   touch "$LOG_FILE"

--- a/utils/config_utils.py
+++ b/utils/config_utils.py
@@ -4,6 +4,10 @@ This module loads environment variables, resolves file paths and provides
 helper functions for broker account lookups. When an account nickname is not
 found in the mapping JSON, :data:`DEFAULT_ACCOUNT_NICKNAME` is used to
 construct a fallback based on broker, group and account numbers.
+
+Set the ``VOLUMES_DIR`` environment variable to override the default
+``volumes/`` directory path. This allows running the bot against external
+storage mounts such as ``/mnt/netstorage/volumes``.
 """
 
 import json
@@ -19,7 +23,9 @@ logger = logging.getLogger(__name__)
 # --- Directories ---
 UTILS_DIR = Path(__file__).resolve().parent
 BASE_DIR = UTILS_DIR.parent
-VOLUMES_DIR = BASE_DIR / "volumes"
+VOLUMES_DIR = Path(
+    os.getenv("VOLUMES_DIR", str(BASE_DIR / "volumes"))
+).resolve()
 CONFIG_DIR = VOLUMES_DIR / "config"
 
 # --- Config paths ---
@@ -165,7 +171,10 @@ def load_config():
         },
         "logging": {
             "level": os.getenv("LOG_LEVEL", "INFO"),
-            "file": os.getenv("LOG_FILE", "volumes/logs/rsassistant.log"),
+            "file": os.getenv(
+                "LOG_FILE",
+                str(VOLUMES_DIR / "logs" / "rsassistant.log"),
+            ),
             "backup_count": int(os.getenv("LOG_BACKUP_COUNT", 2)),
         },
         "environment": {
@@ -179,7 +188,10 @@ def load_config():
         },
         "heartbeat": {
             "enabled": os.getenv("HEARTBEAT_ENABLED", "true").lower() == "true",
-            "path": os.getenv("HEARTBEAT_PATH", "volumes/logs/heartbeat.txt"),
+            "path": os.getenv(
+                "HEARTBEAT_PATH",
+                str(VOLUMES_DIR / "logs" / "heartbeat.txt"),
+            ),
             "interval": int(os.getenv("HEARTBEAT_INTERVAL", 60)),
         },
     }

--- a/utils/logging_setup.py
+++ b/utils/logging_setup.py
@@ -11,6 +11,7 @@ from logging.handlers import RotatingFileHandler
 from datetime import datetime
 from threading import Thread
 from colorama import Fore, Style
+from utils.config_utils import VOLUMES_DIR
 
 
 class ReplaceInvalidCharactersFilter(logging.Filter):
@@ -19,7 +20,9 @@ class ReplaceInvalidCharactersFilter(logging.Filter):
         return True
 
 
-def start_heartbeat_writer(path="./volumes/logs/heartbeat.txt", interval=60):
+def start_heartbeat_writer(
+    path=str(VOLUMES_DIR / "logs" / "heartbeat.txt"), interval=60
+):
     def writer():
         while True:
             try:
@@ -41,9 +44,9 @@ def setup_logging(config=None, verbose=False):
         else "INFO"
     )
     log_file = (
-        config.get("logging", {}).get("file", "logs/app.log")
+        config.get("logging", {}).get("file", str(VOLUMES_DIR / "logs" / "app.log"))
         if config
-        else "volumes/logs/app.log"
+        else str(VOLUMES_DIR / "logs" / "app.log")
     )
     max_size = 10485760
     backup_count = config.get("logging", {}).get("backup_count", 2) if config else 2

--- a/utils/policy_resolver.py
+++ b/utils/policy_resolver.py
@@ -4,9 +4,11 @@
 import os
 import requests
 import re
+from pathlib import Path
 from bs4 import BeautifulSoup
 from utils.logging_setup import logger
 from utils.sec_policy_fetcher import SECPolicyFetcher
+from utils.config_utils import VOLUMES_DIR
 
 
 class SplitPolicyResolver:
@@ -161,7 +163,11 @@ class SplitPolicyResolver:
         return None
 
     @staticmethod
-    def log_full_return(url, text, log_file="volumes/logs/source_return.log"):
+    def log_full_return(
+        url,
+        text,
+        log_file=str(VOLUMES_DIR / "logs" / "source_return.log"),
+    ):
         """Append fetched text to a log file for reference."""
         try:
             os.makedirs(os.path.dirname(log_file), exist_ok=True)

--- a/volumes/config/example.env
+++ b/volumes/config/example.env
@@ -4,7 +4,9 @@ DISCORD_SECONDARY_CHANNEL=channel_id_with_rss_feeds
 DISCORD_SUMMARY_CHANNEL=channel_for_watchlists_etc
 ENV=production
 LOG_LEVEL=INFO
-LOG_FILE=volumes/logs/rsassistant.log
+VOLUMES_DIR=/mnt/netstorage/volumes
+# The following paths default to the VOLUMES_DIR location when unset.
+LOG_FILE=
 HEARTBEAT_ENABLED=true
-HEARTBEAT_PATH=volumes/logs/heartbeat.txt
+HEARTBEAT_PATH=
 HEARTBEAT_INTERVAL=60


### PR DESCRIPTION
## Summary
- allow overriding the `volumes/` directory via new `VOLUMES_DIR` env var
- update logging and policy utilities to reference the configured directory
- respect `VOLUMES_DIR` in the container entrypoint
- document the option in example envs and README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889933158a08329a8ba94e34f5618e1