### PR TITLE
Switch price fetch to OpenBB

### DIFF
--- a/RSAssistant.py
+++ b/RSAssistant.py
@@ -525,6 +525,7 @@ async def brokerlist(ctx, broker: str = None):
 
 @bot.command(
     name="bw",
+    aliases=["brokerwith"],
     help="Show which brokers hold a given ticker.",
     usage="<ticker> [broker]",
     extras={"category": "Reporting"},

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ rich==14.0.0
 selenium==4.31.0
 webdriver_manager==4.0.2
 yfinance==0.2.56
+openbb==4.4.5

--- a/unittests/yfinance_cache_test.py
+++ b/unittests/yfinance_cache_test.py
@@ -3,8 +3,7 @@
 import sys
 from pathlib import Path
 from types import SimpleNamespace
-
-import pandas as pd
+import types
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -27,11 +26,12 @@ def test_get_price_persists_and_loads(tmp_path, monkeypatch):
         SimpleNamespace(time=lambda: fake_time),
     )
 
-    class DummyTicker:
-        def history(self, period="1d"):
-            return pd.DataFrame({"Close": [10.0]})
-
-    monkeypatch.setattr(yfinance_cache.yf, "Ticker", lambda t: DummyTicker())
+    dummy_result = types.SimpleNamespace(results=[types.SimpleNamespace(close=10.0, last_price=None)])
+    monkeypatch.setattr(
+        yfinance_cache.obb.equity.price.__class__,
+        "quote",
+        lambda self, symbol=None, provider=None: dummy_result,
+    )
     price = yfinance_cache.get_price("ABC")
     assert price == 10.0
     assert cache_file.exists()
@@ -39,7 +39,11 @@ def test_get_price_persists_and_loads(tmp_path, monkeypatch):
     # Clear in-memory cache to force reload from disk
     monkeypatch.setattr(yfinance_cache, "_CACHE", {})
     monkeypatch.setattr(yfinance_cache, "_FILE_CACHE_LOADED", False)
-    monkeypatch.setattr(yfinance_cache.yf, "Ticker", lambda t: (_ for _ in ()).throw(AssertionError()))
+    monkeypatch.setattr(
+        yfinance_cache.obb.equity.price.__class__,
+        "quote",
+        lambda self, symbol=None, provider=None: (_ for _ in ()).throw(AssertionError()),
+    )
 
     price = yfinance_cache.get_price("ABC")
     assert price == 10.0

--- a/utils/utility_utils.py
+++ b/utils/utility_utils.py
@@ -13,7 +13,6 @@ from pathlib import Path
 
 import discord
 import yaml
-import yfinance as yf
 from utils.yfinance_cache import get_price
 
 from utils.config_utils import (


### PR DESCRIPTION
## Summary
- update price cache module to use OpenBB instead of direct yfinance calls
- add alias for `bw` command as `brokerwith`
- adjust tests for OpenBB integration
- add OpenBB as a dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cd0cc333c8329888c3e961679ed69