### PR TITLE
feat: consolidate broker holdings checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ RSAssistant is a Discord bot that monitors corporate actions and automates tradi
 - Maintains watch and sell lists with automatic reminders.
 - Schedules buy or sell orders and executes them via autoRSA.
 - The `..all` command refreshes holdings, audits them against the watchlist,
-  and posts a summary of any missing tickers.
+  and posts a summary of any missing tickers alongside a consolidated broker
+  holdings status embed.
 - Stores logs and a SQLite database under `volumes/` for persistence. Set
   the `VOLUMES_DIR` environment variable to use a different location (e.g.
   `/mnt/netstorage/volumes`).
@@ -56,8 +57,9 @@ If you want RSAssistant to store data in an external location, set the
 python RSAssistant.py
 ```
 
-The bot's `..all` command now audits your holdings against the watchlist and
-summarizes any tickers that are missing from your accounts.
+The bot's `..all` command now audits your holdings against the watchlist,
+summarizes any tickers that are missing from your accounts, and consolidates
+broker holdings status into a single embed.
 
 ### Docker
 


### PR DESCRIPTION
## Summary
- consolidate broker holdings check output from `..all` into a single summary embed
- allow `track_ticker_summary` to return broker status data for aggregation
- ensure AutoRSA completion message originates from a bot

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f287a33408329a5cac9bc9bdf82f4