### PR TITLE
feat: auto map broker accounts

### DIFF
--- a/RSAssistant.py
+++ b/RSAssistant.py
@@ -101,8 +101,12 @@ class CategoryHelpCommand(commands.MinimalHelpCommand):
         if note:
             self.paginator.add_line(note, empty=True)
 
-        filtered = await self.filter_commands(bot.commands, sort=True, key=self.get_category)
-        for category, commands_iter in itertools.groupby(filtered, key=self.get_category):
+        filtered = await self.filter_commands(
+            bot.commands, sort=True, key=self.get_category
+        )
+        for category, commands_iter in itertools.groupby(
+            filtered, key=self.get_category
+        ):
             self.paginator.add_line(f"__**{category}**__")
             for command in commands_iter:
                 self.add_command_formatting(command)
@@ -116,6 +120,7 @@ class CategoryHelpCommand(commands.MinimalHelpCommand):
         self.paginator.add_line(f"__**Category:** {category}__", empty=True)
         self.add_command_formatting(command)
         await self.send_pages()
+
 
 # Set up bot intents
 intents = discord.Intents.default()
@@ -527,6 +532,7 @@ async def brokerlist(ctx, broker: str = None):
     name="bw",
     help="Show which brokers hold a given ticker.",
     usage="<ticker> [broker]",
+    aliases=["brokerwith"],
     extras={"category": "Reporting"},
 )
 async def broker_has(ctx, ticker: str, *args):

--- a/unittests/config_utils_test.py
+++ b/unittests/config_utils_test.py
@@ -1,0 +1,17 @@
+import json
+from pathlib import Path
+
+from utils import config_utils
+
+
+def test_get_account_nickname_creates_mapping(tmp_path, monkeypatch):
+    tmp_mapping = tmp_path / "account_mapping.json"
+    monkeypatch.setattr(config_utils, "ACCOUNT_MAPPING", tmp_mapping)
+
+    nickname = config_utils.get_account_nickname("TestBroker", "1", "1234")
+    assert nickname == "TestBroker 1 1234"
+
+    with open(tmp_mapping, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    assert data == {"TestBroker": {"1": {"1234": "TestBroker 1 1234"}}}


### PR DESCRIPTION
## Summary
- add `brokerwith` alias for `..bw`
- automatically persist default account nicknames when unmapped brokerages are encountered
- document and test automatic account mapping

## Testing
- `black --check RSAssistant.py utils/config_utils.py unittests/config_utils_test.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a378bb1ca48329bd5532e0359229d1