### PR TITLE
feat: auto-restart bot on merged PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,22 @@ When an account has no nickname in `account_mapping.json`, RSAssistant falls
 back to the pattern `"{broker} {group} {account}"`. This ensures new accounts
 and orders are always logged with a deterministic identifier.
 
+## Pull Request Watcher
+
+`pr_watcher.py` monitors the GitHub repository for merged pull requests. When a merge is detected, it stops the running bot, executes `git pull`, and restarts the bot with the latest code.
+
+Run the watcher with:
+
+```bash
+python pr_watcher.py
+```
+
+Set the following environment variables to customize behavior:
+
+- `GITHUB_REPO`: repository in `owner/name` form (default: `your-org/RSAssistant`)
+- `GITHUB_TOKEN`: optional token for authenticated requests
+- `PR_WATCH_INTERVAL`: polling interval in seconds (default: 60)
+
 ## Testing
 
 Run unit tests with:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,4 +37,4 @@ fi
 
 # Start the main script
 echo "Starting RSAssistant script..."
-exec python /app/RSAssistant.py
+exec python /app/pr_watcher.py

--- a/pr_watcher.py
+++ b/pr_watcher.py
@@ -1,0 +1,84 @@
+"""GitHub PR watcher for RSAssistant.
+
+This module runs the RSAssistant bot and silently polls the GitHub
+repository for merged pull requests. When a new merge is detected, the
+current bot process is terminated, the repository is updated via
+``git pull``, and the bot is restarted. The polling interval and
+repository can be configured through environment variables.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from datetime import datetime, timezone
+from typing import Optional
+
+import requests
+
+POLL_INTERVAL = int(os.environ.get("PR_WATCH_INTERVAL", "60"))
+GITHUB_REPO = os.environ.get("GITHUB_REPO", "your-org/RSAssistant")
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
+
+
+def fetch_latest_merge_time() -> Optional[datetime]:
+    """Return the ``merged_at`` time of the most recently merged PR.
+
+    The function queries the GitHub API for the most recently updated
+    closed pull request and returns its ``merged_at`` timestamp if the
+    PR was merged. ``None`` is returned when no merged pull requests are
+    found.
+    """
+
+    headers = {"Accept": "application/vnd.github+json"}
+    if GITHUB_TOKEN:
+        headers["Authorization"] = f"token {GITHUB_TOKEN}"
+
+    url = (
+        f"https://api.github.com/repos/{GITHUB_REPO}/pulls?state=closed&per_page=1&sort=updated&direction=desc"
+    )
+    response = requests.get(url, headers=headers, timeout=10)
+    response.raise_for_status()
+    prs = response.json()
+    if prs and prs[0].get("merged_at"):
+        return datetime.fromisoformat(prs[0]["merged_at"].replace("Z", "+00:00"))
+    return None
+
+
+def should_restart(last_merge: Optional[datetime], latest_merge: Optional[datetime]) -> bool:
+    """Return ``True`` when a new merge has occurred since ``last_merge``."""
+
+    return (
+        last_merge is not None
+        and latest_merge is not None
+        and latest_merge > last_merge
+    )
+
+
+def run_bot() -> subprocess.Popen:
+    """Launch the RSAssistant bot process."""
+
+    return subprocess.Popen(["python", "RSAssistant.py"])
+
+
+def main() -> None:
+    """Run the watcher and restart the bot on merged pull requests."""
+
+    bot_proc = run_bot()
+    last_merge = fetch_latest_merge_time()
+
+    while True:
+        time.sleep(POLL_INTERVAL)
+        latest_merge = fetch_latest_merge_time()
+        if should_restart(last_merge, latest_merge):
+            bot_proc.terminate()
+            bot_proc.wait()
+            subprocess.run(["git", "pull"], check=True)
+            bot_proc = run_bot()
+        if latest_merge is not None:
+            last_merge = latest_merge
+
+
+if __name__ == "__main__":
+    main()

--- a/unittests/pr_watcher_test.py
+++ b/unittests/pr_watcher_test.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+from datetime import datetime, timezone
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import pr_watcher
+
+
+def test_should_restart():
+    last = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    latest = datetime(2024, 1, 2, tzinfo=timezone.utc)
+    assert pr_watcher.should_restart(last, latest)
+    assert not pr_watcher.should_restart(latest, last)
+    assert not pr_watcher.should_restart(None, latest)
+
+
+def test_fetch_latest_merge_time(monkeypatch):
+    class FakeResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return [{"merged_at": "2024-01-01T00:00:00Z"}]
+
+    monkeypatch.setattr(pr_watcher.requests, "get", lambda *a, **k: FakeResp())
+    assert pr_watcher.fetch_latest_merge_time() == datetime(2024, 1, 1, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary
- add `pr_watcher.py` to poll GitHub for merged pull requests and restart the bot after updating
- start watcher via container entrypoint for seamless auto-updates
- document watcher usage and environment variables
- cover watcher logic with unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae84ff26508329bec4293e082f42fa