### PR TITLE
Route reverse split alerts to tertiary channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,21 @@ The bot's `..all` command now audits your holdings against the watchlist,
 summarizes any tickers that are missing from your accounts, and consolidates
 broker holdings status into a single embed.
 
+### Discord channel configuration
+
+RSAssistant differentiates between three Discord channels so information lands
+where it is most actionable:
+
+- `DISCORD_PRIMARY_CHANNEL`: Operational commands, holdings refresh output, and
+  scheduled order confirmations.
+- `DISCORD_SECONDARY_CHANNEL`: Source feed where NASDAQ and SEC alerts arrive.
+- `DISCORD_TERTIARY_CHANNEL`: Destination for reverse split summaries and the
+  associated policy snippets parsed from filings or press releases.
+
+Populate the corresponding environment variables in your `.env` file with the
+channel IDs for your server. When the tertiary channel ID is omitted, the bot
+falls back to the primary channel to avoid dropping critical alerts.
+
 ### Configuration: Auto Refresh + Monitor
 
 Add the following keys to your environment. The app now loads from a single source:

--- a/config/example.env
+++ b/config/example.env
@@ -4,7 +4,7 @@ BOT_TOKEN=
 DISCORD_PRIMARY_CHANNEL=
 # -- Nasdaq Corporate Actions RSS Feed
 DISCORD_SECONDARY_CHANNEL=
-# -- I forget what I have this channel defined for
+# -- Reverse split summaries + snippets destination
 DISCORD_TERTIARY_CHANNEL=
 
 # Optional path to the persistent data directory. Defaults to

--- a/utils/on_message_utils.py
+++ b/utils/on_message_utils.py
@@ -359,7 +359,12 @@ async def handle_primary_channel(bot, message):
 
 
 async def handle_secondary_channel(bot, message):
-    """Handle NASDAQ alerts posted in the secondary channel."""
+    """Handle NASDAQ alerts posted in the secondary channel.
+
+    Reverse split policy summaries and supporting snippets are forwarded to
+    the tertiary channel when it is configured. Other operational messages
+    continue to use their original destinations.
+    """
     logger.info(f"Received message on secondary channel: {message.content}")
     result = alert_channel_message(message.content)
     logger.info(f"Alert parser result: {result}")
@@ -388,7 +393,22 @@ async def handle_secondary_channel(bot, message):
             context = f"Round-up snippet from {url}: "
             snippet = body_text[: 2000 - len(context)]
             logger.info(f"Posting body text snippet for {ticker}")
-            await message.channel.send(context + snippet)
+
+            target_channel = None
+            if DISCORD_TERTIARY_CHANNEL:
+                target_channel = bot.get_channel(DISCORD_TERTIARY_CHANNEL)
+                if not target_channel:
+                    logger.error(
+                        "Tertiary channel %s not found; unable to post snippet to tertiary.",
+                        DISCORD_TERTIARY_CHANNEL,
+                    )
+            if not target_channel:
+                logger.warning(
+                    "Falling back to secondary channel for %s snippet delivery.", ticker
+                )
+                target_channel = message.channel
+
+            await target_channel.send(context + snippet)
 
         if policy_info.get("round_up_confirmed"):
             await attempt_autobuy(bot, message.channel, ticker, quantity=1)
@@ -464,12 +484,43 @@ def build_policy_summary(ticker, policy_info, fallback_url):
 
 
 async def post_policy_summary(bot, ticker, summary):
-    chan = bot.get_channel(DISCORD_PRIMARY_CHANNEL)
-    if chan:
-        await chan.send(summary)
-        logger.info(f"Posted policy summary for {ticker}")
-    else:
-        logger.error("Primary channel unavailable")
+    """Send a reverse split policy summary to the tertiary channel.
+
+    If the tertiary channel ID is not configured or cannot be resolved, the
+    summary falls back to the primary channel so the alert is not lost.
+
+    Args:
+        bot: Active Discord bot/client instance.
+        ticker: The ticker symbol associated with the alert.
+        summary: Rendered summary text to post.
+    """
+
+    channel = None
+    if DISCORD_TERTIARY_CHANNEL:
+        channel = bot.get_channel(DISCORD_TERTIARY_CHANNEL)
+        if not channel:
+            logger.error(
+                "Tertiary channel %s not found; reverse split summary will fallback.",
+                DISCORD_TERTIARY_CHANNEL,
+            )
+
+    if not channel and DISCORD_PRIMARY_CHANNEL:
+        channel = bot.get_channel(DISCORD_PRIMARY_CHANNEL)
+        if channel:
+            logger.warning(
+                "Posting %s reverse split summary to primary channel fallback.", ticker
+            )
+
+    if not channel:
+        logger.error(
+            "Unable to resolve a channel for %s reverse split summary.", ticker
+        )
+        return
+
+    await channel.send(summary)
+    logger.info(
+        "Posted policy summary for %s to channel %s", ticker, getattr(channel, "id", "unknown")
+    )
 
 
 


### PR DESCRIPTION
## Summary
- direct reverse split policy summaries and snippets to the tertiary Discord channel when configured
- document the channel roles in the README and clarify the tertiary channel purpose in config/example.env
- fall back to the primary channel if the tertiary channel ID is missing to avoid dropping alerts

## Testing
- python -m unittest discover -s unittests -p '*_test.py'

------
https://chatgpt.com/codex/tasks/task_e_68c9c454765c8329bfa5e6bf8ca6af14