### PR TITLE
Add broker ignore support for alerts and auto sell

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Add the following keys to your environment. The app now loads from a single sour
 - `AUTO_SELL_LIVE` (bool): If `true`, also post `..ord sell {ticker} {broker} {quantity}`. Default `false`.
 - `IGNORE_TICKERS` (CSV): Tickers to skip for alert/auto-sell (e.g., `ABCD,EFGH`). Default empty.
 - `IGNORE_TICKERS_FILE` (path, optional): File containing one ticker per line to ignore. Defaults to `volumes/config/ignore_tickers.txt`. Lines starting with `#` are treated as comments.
+- `IGNORE_BROKERS` (CSV): Brokers to skip for alert/auto-sell (e.g., `Fidelity,Schwab`). Default empty.
+- `IGNORE_BROKERS_FILE` (path, optional): File containing one broker name per line to ignore. Defaults to `volumes/config/ignore_brokers.txt`. Lines starting with `#` are treated as comments.
 
 You can use either the env var, the file, or both — the sets merge. Create the file like:
 
@@ -114,6 +116,9 @@ cp config/ignore_tickers.example.txt volumes/config/ignore_tickers.txt
 echo "AAPL" >> volumes/config/ignore_tickers.txt
 echo "MSFT  # Long-term" >> volumes/config/ignore_tickers.txt
 ```
+
+Apply the same approach for brokers by creating `volumes/config/ignore_brokers.txt`
+with one broker name per line.
 
 - `MENTION_USER_ID` (string): Your Discord user ID to @-mention in alerts (e.g., `123456789012345678`). Optional.
 - `MENTION_ON_ALERTS` (bool): Enable/disable mentions on alerts. Default `true`.

--- a/config/example.env
+++ b/config/example.env
@@ -24,6 +24,12 @@ HOLDING_ALERT_MIN_PRICE=1
 AUTO_SELL_LIVE=false
 # Comma-separated tickers to ignore for alert/auto-sell (e.g., ABCD,EFGH)
 IGNORE_TICKERS=
+# Optional override for ticker ignore list path (defaults to volumes/config/ignore_tickers.txt)
+IGNORE_TICKERS_FILE=
+# Comma-separated brokers to ignore for alert/auto-sell (e.g., Fidelity,Schwab)
+IGNORE_BROKERS=
+# Optional override for broker ignore list path (defaults to volumes/config/ignore_brokers.txt)
+IGNORE_BROKERS_FILE=
 
 # --- Mentions ---
 # Set your Discord user ID to @-mention you in alerts (e.g., 123456789012345678)

--- a/unittests/config_utils_test.py
+++ b/unittests/config_utils_test.py
@@ -37,6 +37,23 @@ def test_ignore_tickers_file_and_env_merge(tmp_path, monkeypatch):
     assert merged == {"AAPL", "MSFT", "GOOG", "AMZN"}
 
 
+def test_ignore_brokers_file_and_env_merge(tmp_path, monkeypatch):
+    ignore_file = tmp_path / "ignore_brokers.txt"
+    ignore_file.write_text("""
+    Fidelity
+    Schwab  # Workplace plan
+
+
+    """.strip(), encoding="utf-8")
+
+    monkeypatch.setattr(config_utils, "IGNORE_BROKERS_FILE", ignore_file)
+    monkeypatch.setenv("IGNORE_BROKERS", "tasty, , robinhood ")
+
+    merged = config_utils._compute_ignore_brokers()
+
+    assert merged == {"FIDELITY", "SCHWAB", "TASTY", "ROBINHOOD"}
+
+
 def test_persistence_defaults_true():
     assert config_utils.CSV_LOGGING_ENABLED
     assert config_utils.EXCEL_LOGGING_ENABLED

--- a/unittests/on_message_utils_test.py
+++ b/unittests/on_message_utils_test.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from utils.on_message_utils import compute_account_missing_tickers
+from utils import on_message_utils
 from utils.watch_utils import watch_list_manager
 
 
@@ -18,8 +18,21 @@ def test_compute_account_missing_tickers(monkeypatch):
         {"broker": "Test", "account_name": "Nick1", "account": "1111", "ticker": "CCC"},
         {"broker": "Test", "account_name": "Nick2", "account": "2222", "ticker": "BBB"},
     ]
-    result = compute_account_missing_tickers(holdings)
+    result = on_message_utils.compute_account_missing_tickers(holdings)
     assert result == {
         "Test Nick1 (1111)": ["BBB"],
         "Test Nick2 (2222)": ["AAA"],
     }
+
+
+def test_is_broker_ignored(monkeypatch):
+    monkeypatch.setattr(
+        on_message_utils,
+        "IGNORE_BROKERS_SET",
+        {"TASTYWORKS", "TD AMERITRADE"},
+    )
+
+    assert on_message_utils.is_broker_ignored("tastyworks") is True
+    assert on_message_utils.is_broker_ignored("  td ameritrade  ") is True
+    assert on_message_utils.is_broker_ignored("Fidelity") is False
+    assert on_message_utils.is_broker_ignored("") is False

--- a/utils/on_message_utils.py
+++ b/utils/on_message_utils.py
@@ -27,6 +27,7 @@ from utils.config_utils import (
     AUTO_SELL_LIVE,
     HOLDING_ALERT_MIN_PRICE,
     IGNORE_TICKERS as IGNORE_TICKERS_SET,
+    IGNORE_BROKERS as IGNORE_BROKERS_SET,
     DISCORD_PRIMARY_CHANNEL as PRIMARY_CHAN_ID,
     MENTION_USER_ID,
     MENTION_ON_ALERTS,
@@ -48,6 +49,14 @@ _missing_summary = defaultdict(set)
 _refresh_active = False
 _pending_alerts_by_broker = defaultdict(set)  # broker -> set[ticker]
 _pending_sell_commands = []  # queued auto-sell commands during refresh
+
+
+def is_broker_ignored(broker: str) -> bool:
+    """Return ``True`` when ``broker`` is configured to skip alerts/auto-sell."""
+
+    if not broker:
+        return False
+    return broker.strip().upper() in IGNORE_BROKERS_SET
 
 
 def enable_audit():
@@ -225,6 +234,8 @@ async def handle_primary_channel(bot, message):
                     price = float(h.get("price", 0) or 0)
                     quantity = float(h.get("quantity", 0) or 0)
                     broker = str(h.get("broker", "")).strip()
+                    if is_broker_ignored(broker):
+                        continue
                     account_name = str(h.get("account_name", h.get("account", "")))
                     if price < threshold or quantity <= 0:
                         continue


### PR DESCRIPTION
## Summary
- add IGNORE_BROKERS environment/file configuration that merges with the existing ticker ignore list
- skip holdings alert and auto-sell processing when the broker is configured to be ignored
- document the new settings and exercise them with config and message utility unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9c51ac9e08329a9c9081a5fe8d658