### PR TITLE
fix: preserve ticker-specific holdings summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,21 @@ The bot's `..all` command now audits your holdings against the watchlist,
 summarizes any tickers that are missing from your accounts, and consolidates
 broker holdings status into a single embed.
 
+### Discord channel configuration
+
+RSAssistant differentiates between three Discord channels so information lands
+where it is most actionable:
+
+- `DISCORD_PRIMARY_CHANNEL`: Operational commands, holdings refresh output, and
+  scheduled order confirmations.
+- `DISCORD_SECONDARY_CHANNEL`: Source feed where NASDAQ and SEC alerts arrive.
+- `DISCORD_TERTIARY_CHANNEL`: Destination for reverse split summaries and the
+  associated policy snippets parsed from filings or press releases.
+
+Populate the corresponding environment variables in your `.env` file with the
+channel IDs for your server. When the tertiary channel ID is omitted, the bot
+falls back to the primary channel to avoid dropping critical alerts.
+
 ### Configuration: Auto Refresh + Monitor
 
 Add the following keys to your environment. The app now loads from a single source:
@@ -106,6 +121,8 @@ Add the following keys to your environment. The app now loads from a single sour
 - `AUTO_SELL_LIVE` (bool): If `true`, also post `..ord sell {ticker} {broker} {quantity}`. Default `false`.
 - `IGNORE_TICKERS` (CSV): Tickers to skip for alert/auto-sell (e.g., `ABCD,EFGH`). Default empty.
 - `IGNORE_TICKERS_FILE` (path, optional): File containing one ticker per line to ignore. Defaults to `volumes/config/ignore_tickers.txt`. Lines starting with `#` are treated as comments.
+- `IGNORE_BROKERS` (CSV): Brokers to skip for alert/auto-sell (e.g., `Fidelity,Schwab`). Default empty.
+- `IGNORE_BROKERS_FILE` (path, optional): File containing one broker name per line to ignore. Defaults to `volumes/config/ignore_brokers.txt`. Lines starting with `#` are treated as comments.
 
 You can use either the env var, the file, or both — the sets merge. Create the file like:
 
@@ -114,6 +131,9 @@ cp config/ignore_tickers.example.txt volumes/config/ignore_tickers.txt
 echo "AAPL" >> volumes/config/ignore_tickers.txt
 echo "MSFT  # Long-term" >> volumes/config/ignore_tickers.txt
 ```
+
+Apply the same approach for brokers by creating `volumes/config/ignore_brokers.txt`
+with one broker name per line.
 
 - `MENTION_USER_ID` (string): Your Discord user ID to @-mention in alerts (e.g., `123456789012345678`). Optional.
 - `MENTION_ON_ALERTS` (bool): Enable/disable mentions on alerts. Default `true`.

--- a/config/example.env
+++ b/config/example.env
@@ -4,7 +4,7 @@ BOT_TOKEN=
 DISCORD_PRIMARY_CHANNEL=
 # -- Nasdaq Corporate Actions RSS Feed
 DISCORD_SECONDARY_CHANNEL=
-# -- I forget what I have this channel defined for
+# -- Reverse split summaries + snippets destination
 DISCORD_TERTIARY_CHANNEL=
 
 # Optional path to the persistent data directory. Defaults to
@@ -24,6 +24,12 @@ HOLDING_ALERT_MIN_PRICE=1
 AUTO_SELL_LIVE=false
 # Comma-separated tickers to ignore for alert/auto-sell (e.g., ABCD,EFGH)
 IGNORE_TICKERS=
+# Optional override for ticker ignore list path (defaults to volumes/config/ignore_tickers.txt)
+IGNORE_TICKERS_FILE=
+# Comma-separated brokers to ignore for alert/auto-sell (e.g., Fidelity,Schwab)
+IGNORE_BROKERS=
+# Optional override for broker ignore list path (defaults to volumes/config/ignore_brokers.txt)
+IGNORE_BROKERS_FILE=
 
 # --- Mentions ---
 # Set your Discord user ID to @-mention you in alerts (e.g., 123456789012345678)

--- a/unittests/config_utils_test.py
+++ b/unittests/config_utils_test.py
@@ -37,6 +37,23 @@ def test_ignore_tickers_file_and_env_merge(tmp_path, monkeypatch):
     assert merged == {"AAPL", "MSFT", "GOOG", "AMZN"}
 
 
+def test_ignore_brokers_file_and_env_merge(tmp_path, monkeypatch):
+    ignore_file = tmp_path / "ignore_brokers.txt"
+    ignore_file.write_text("""
+    Fidelity
+    Schwab  # Workplace plan
+
+
+    """.strip(), encoding="utf-8")
+
+    monkeypatch.setattr(config_utils, "IGNORE_BROKERS_FILE", ignore_file)
+    monkeypatch.setenv("IGNORE_BROKERS", "tasty, , robinhood ")
+
+    merged = config_utils._compute_ignore_brokers()
+
+    assert merged == {"FIDELITY", "SCHWAB", "TASTY", "ROBINHOOD"}
+
+
 def test_persistence_defaults_true():
     assert config_utils.CSV_LOGGING_ENABLED
     assert config_utils.EXCEL_LOGGING_ENABLED

--- a/unittests/on_message_utils_test.py
+++ b/unittests/on_message_utils_test.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from utils.on_message_utils import compute_account_missing_tickers
+from utils import on_message_utils
 from utils.watch_utils import watch_list_manager
 
 
@@ -18,8 +18,21 @@ def test_compute_account_missing_tickers(monkeypatch):
         {"broker": "Test", "account_name": "Nick1", "account": "1111", "ticker": "CCC"},
         {"broker": "Test", "account_name": "Nick2", "account": "2222", "ticker": "BBB"},
     ]
-    result = compute_account_missing_tickers(holdings)
+    result = on_message_utils.compute_account_missing_tickers(holdings)
     assert result == {
         "Test Nick1 (1111)": ["BBB"],
         "Test Nick2 (2222)": ["AAA"],
     }
+
+
+def test_is_broker_ignored(monkeypatch):
+    monkeypatch.setattr(
+        on_message_utils,
+        "IGNORE_BROKERS_SET",
+        {"TASTYWORKS", "TD AMERITRADE"},
+    )
+
+    assert on_message_utils.is_broker_ignored("tastyworks") is True
+    assert on_message_utils.is_broker_ignored("  td ameritrade  ") is True
+    assert on_message_utils.is_broker_ignored("Fidelity") is False
+    assert on_message_utils.is_broker_ignored("") is False

--- a/unittests/utility_utils_test.py
+++ b/unittests/utility_utils_test.py
@@ -1,5 +1,10 @@
+"""Tests for helpers in :mod:`utils.utility_utils`."""
+
+import asyncio
+import csv
 import sys
 from pathlib import Path
+
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -18,3 +23,95 @@ def test_aggregate_owner_totals(monkeypatch):
 
     totals = utility_utils.aggregate_owner_totals()
     assert totals == {"OwnerA": 125.0, "OwnerB": 75.0, "OwnerC": 10.0}
+
+
+def test_track_ticker_summary_multiple_ticker_refresh(tmp_path, monkeypatch):
+    """Multiple tickers for one account should not hide earlier holdings."""
+
+    csv_path = tmp_path / "holdings.csv"
+    fieldnames = [
+        "Timestamp",
+        "Broker Name",
+        "Key",
+        "Stock",
+        "Quantity",
+        "Price",
+        "Account Total",
+    ]
+    with csv_path.open("w", newline="", encoding="utf-8") as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerow(
+            {
+                "Timestamp": "2024-01-01 09:30:00",
+                "Broker Name": "BrokerA",
+                "Key": "BrokerA Alpha",
+                "Stock": "AAA",
+                "Quantity": "10",
+                "Price": "5",
+                "Account Total": "100",
+            }
+        )
+        writer.writerow(
+            {
+                "Timestamp": "2024-01-01 09:30:00",
+                "Broker Name": "BrokerA",
+                "Key": "BrokerA Alpha",
+                "Stock": "BBB",
+                "Quantity": "5",
+                "Price": "15",
+                "Account Total": "150",
+            }
+        )
+        writer.writerow(
+            {
+                "Timestamp": "2024-01-01 09:30:00",
+                "Broker Name": "BrokerA",
+                "Key": "BrokerA Beta",
+                "Stock": "CCC",
+                "Quantity": "2",
+                "Price": "8",
+                "Account Total": "80",
+            }
+        )
+
+    account_mapping = {
+        "BrokerA": {
+            "Group1": {
+                "00000001": "Alpha",
+                "00000002": "Beta",
+            }
+        }
+    }
+
+    monkeypatch.setattr(utility_utils, "load_account_mappings", lambda: account_mapping)
+
+    captured_holdings = {}
+    original_compute = utility_utils.compute_broker_statuses
+
+    def spy_compute(holdings, account_mapping):
+        captured_holdings.clear()
+        for broker, accounts in holdings.items():
+            captured_holdings[broker] = dict(accounts)
+        return original_compute(holdings, account_mapping)
+
+    monkeypatch.setattr(utility_utils, "compute_broker_statuses", spy_compute)
+
+    statuses, timestamp_str = asyncio.run(
+        utility_utils.track_ticker_summary(
+            ctx=None,
+            ticker="AAA",
+            collect=True,
+            holding_logs_file=csv_path,
+        )
+    )
+
+    assert timestamp_str == "2024-01-01 09:30:00"
+    broker_status = statuses["BrokerA"]
+    assert broker_status[0] == "🟡"
+    assert broker_status[1] == 1
+    assert broker_status[2] == 2
+
+    broker_holdings = captured_holdings.get("BrokerA", {})
+    assert "BrokerA Alpha" in broker_holdings
+    assert "BrokerA Beta" not in broker_holdings


### PR DESCRIPTION
## Summary
- filter holdings CSV rows by the requested ticker before deduplicating accounts so mixed refreshes keep each position
- stop adding placeholder ❌ entries and let `compute_broker_statuses` infer missing accounts
- add regression coverage for a multi-ticker refresh in `track_ticker_summary`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9c928342c8329bf2cca5046a9509e