### PR TITLE
Fix price fetch latency by tightening retries and using stale cache fallback

### DIFF
--- a/utils/on_message_utils.py
+++ b/utils/on_message_utils.py
@@ -197,6 +197,11 @@ async def handle_primary_channel(bot, message):
     Embed messages are treated as holdings updates and persisted to the
     holdings CSV log. All other messages are routed to order parsing or
     maintenance commands.
+
+    Notes
+    -----
+    Order messages are parsed in a background thread to keep the Discord
+    heartbeat responsive even if broker APIs respond slowly.
     """
 
     # Detect completion message regardless of author to flush buffered alerts
@@ -344,7 +349,7 @@ async def handle_primary_channel(bot, message):
             await message.channel.send(f"Added {count} tickers to watchlist.")
             logger.info(f"Added {count} tickers from bulk watchlist message.")
             return
-        parse_order_message(message.content)
+        await asyncio.to_thread(parse_order_message, message.content)
 
 
 async def handle_secondary_channel(bot, message):


### PR DESCRIPTION
## Summary
- limit Nasdaq request retries, shorten timeouts, and cache failure timestamps so stale prices can be reused when the API is slow
- execute order parsing in a background thread to keep the Discord gateway responsive while orders are processed
- add regression tests covering stale cache fallback and failure backoff scenarios for the price cache

## Testing
- python -m unittest discover -s unittests -p '*_test.py'
- pytest unittests/price_cache_test.py

------
https://chatgpt.com/codex/tasks/task_e_68d30abb12bc8329908c0b95be9a0df9