### PR TITLE
Add command to remove queued sell orders

### DIFF
--- a/RSAssistant.py
+++ b/RSAssistant.py
@@ -506,6 +506,12 @@ async def send_scheduled_reminder():
     extras={"category": "Watchlist"},
 )
 async def view_sell_list(ctx):
+    """Display queued sell orders stored by the bot.
+
+    Args:
+        ctx (commands.Context): Invocation context for the command.
+    """
+
     sell_list = watch_list_manager.get_sell_list()
     if not sell_list:
         await ctx.send("The sell list is empty.")
@@ -520,6 +526,34 @@ async def view_sell_list(ctx):
             added_on = details.get("added_on", "N/A")
             embed.add_field(name=ticker, value=f"Added on: {added_on}", inline=False)
         await ctx.send(embed=embed)
+
+
+@bot.command(
+    name="unsell",
+    help="Remove a ticker from the sell queue.",
+    usage="<ticker>",
+    extras={"category": "Watchlist"},
+)
+async def remove_sell_order(ctx, ticker: str):
+    """Remove a queued sell order for ``ticker`` from the sell list.
+
+    Args:
+        ctx (commands.Context): Invocation context for the command.
+        ticker (str): Symbol to remove from the sell queue.
+    """
+
+    normalized_ticker = ticker.upper()
+    removed = watch_list_manager.remove_from_sell_list(normalized_ticker)
+
+    if removed:
+        logger.info("Removed %s from sell list via command.", normalized_ticker)
+        await ctx.send(f"{normalized_ticker} removed from the sell list.")
+    else:
+        logger.info(
+            "Attempted to remove %s from sell list but it was not present.",
+            normalized_ticker,
+        )
+        await ctx.send(f"{normalized_ticker} was not found in the sell list.")
 
 
 @bot.command(

--- a/unittests/sell_queue_command_test.py
+++ b/unittests/sell_queue_command_test.py
@@ -1,0 +1,54 @@
+"""Tests for sell queue command helpers."""
+
+import asyncio
+
+import RSAssistant
+
+
+class DummyCtx:
+    """Capture messages sent during command execution."""
+
+    def __init__(self):
+        self.messages = []
+
+    async def send(self, message, **kwargs):  # noqa: D401 - simple passthrough
+        """Store outbound Discord messages for later assertions."""
+
+        self.messages.append(message)
+
+
+def test_remove_sell_order_success(monkeypatch):
+    """The command should remove an existing ticker from the sell list."""
+
+    ctx = DummyCtx()
+    recorded = []
+
+    def fake_remove(ticker):
+        recorded.append(ticker)
+        return True
+
+    monkeypatch.setattr(
+        RSAssistant.watch_list_manager,
+        "remove_from_sell_list",
+        fake_remove,
+    )
+
+    asyncio.run(RSAssistant.remove_sell_order(ctx, "abc"))
+
+    assert recorded == ["ABC"]
+    assert ctx.messages == ["ABC removed from the sell list."]
+
+
+def test_remove_sell_order_not_found(monkeypatch):
+    """The command should report when the ticker is not queued."""
+
+    ctx = DummyCtx()
+    monkeypatch.setattr(
+        RSAssistant.watch_list_manager,
+        "remove_from_sell_list",
+        lambda ticker: False,
+    )
+
+    asyncio.run(RSAssistant.remove_sell_order(ctx, "xyz"))
+
+    assert ctx.messages == ["XYZ was not found in the sell list."]


### PR DESCRIPTION
## Summary
- add the ``..unsell`` command so queued sell tickers can be removed without editing files
- document the ``..selling`` command handler with a usage docstring
- cover success and miss scenarios for removing tickers from the sell queue

## Testing
- python -m unittest discover -s unittests -p '*_test.py'


------
https://chatgpt.com/codex/tasks/task_e_68d37414524c8329a5c881404c954649