### PR TITLE
feat: add GitHub DeepSource monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Configure these via environment variables (see below).
 ```
 .
 ├── RSAssistant.py           # Main bot application
+├── deepsource_monitor.py    # DeepSource GitHub check monitor
 ├── pr_watcher.py            # PR watcher script
 ├── utils/                   # Helper modules and order management
 ├── config/                  # Example env and settings files
@@ -183,6 +184,29 @@ Set the following environment variables to customize behavior:
 - `GITHUB_REPO`: repository in `owner/name` form (default: `braydio/RSAssistant`)
 - `GITHUB_TOKEN`: optional token for authenticated requests
 - `PR_WATCH_INTERVAL`: polling interval in seconds (default: 60)
+
+## DeepSource Monitor
+
+`deepsource_monitor.py` polls the GitHub checks API for the latest DeepSource
+run on the repository's default branch. The script logs whenever the
+DeepSource status changes, making it easy to host the monitor alongside the
+bot or as a standalone health check.
+
+Run the monitor with:
+
+```bash
+python deepsource_monitor.py
+```
+
+Configuration relies on the same GitHub settings used by the PR watcher and
+accepts two additional environment variables:
+
+- `DEEPSOURCE_APP_NAME`: GitHub check app name to match (default: `DeepSource`)
+- `DEEPSOURCE_POLL_INTERVAL`: polling cadence in seconds (default: 300)
+
+The monitor logs informational messages for successful runs, escalates to an
+error log when DeepSource fails, and raises a warning if no DeepSource run is
+found on the latest commit.
 
 ## Testing
 

--- a/deepsource_monitor.py
+++ b/deepsource_monitor.py
@@ -1,0 +1,268 @@
+"""DeepSource GitHub check monitor.
+
+This module polls the GitHub API for the repository's latest commit and
+tracks the DeepSource check run associated with that commit. The monitor
+logs a message whenever the DeepSource status changes, allowing operators
+to host it alongside RSAssistant for continuous quality monitoring.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import requests
+
+POLL_INTERVAL = int(os.environ.get("DEEPSOURCE_POLL_INTERVAL", "300"))
+GITHUB_REPO = os.environ.get("GITHUB_REPO", "braydio/RSAssistant")
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "")
+DEEPSOURCE_APP_NAME = os.environ.get("DEEPSOURCE_APP_NAME", "DeepSource")
+SUCCESS_CONCLUSIONS = {"success", "neutral", "skipped"}
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CheckRunState:
+    """Container describing a GitHub check run."""
+
+    run_id: int
+    status: str
+    conclusion: Optional[str]
+    html_url: Optional[str]
+
+    @property
+    def is_failure(self) -> bool:
+        """bool: ``True`` when the check finished with a failing result."""
+
+        return (
+            self.status == "completed"
+            and (self.conclusion or "").lower() not in SUCCESS_CONCLUSIONS
+        )
+
+
+@dataclass(frozen=True)
+class MonitorSnapshot:
+    """Snapshot of the DeepSource status for a commit."""
+
+    commit_sha: str
+    check_run: Optional[CheckRunState]
+
+
+def _github_headers() -> Dict[str, str]:
+    """Return HTTP headers for GitHub API requests."""
+
+    headers = {"Accept": "application/vnd.github+json"}
+    if GITHUB_TOKEN:
+        headers["Authorization"] = f"token {GITHUB_TOKEN}"
+    return headers
+
+
+def fetch_default_branch() -> str:
+    """Return the default branch for :data:`GITHUB_REPO`.
+
+    Returns:
+        str: Default branch name.
+
+    Raises:
+        requests.HTTPError: If GitHub returns an error response.
+        ValueError: When the API response lacks the ``default_branch`` key.
+    """
+
+    url = f"https://api.github.com/repos/{GITHUB_REPO}"
+    response = requests.get(url, headers=_github_headers(), timeout=10)
+    response.raise_for_status()
+    data = response.json()
+    branch = data.get("default_branch")
+    if not branch:
+        raise ValueError("GitHub repository response missing default_branch")
+    return branch
+
+
+def fetch_latest_commit_sha(branch: str) -> str:
+    """Return the SHA of the latest commit on ``branch``.
+
+    Args:
+        branch: Branch to inspect.
+
+    Returns:
+        str: SHA hash of the newest commit on ``branch``.
+
+    Raises:
+        requests.HTTPError: If GitHub returns an error response.
+        ValueError: If the response does not contain a commit ``sha`` field.
+    """
+
+    url = f"https://api.github.com/repos/{GITHUB_REPO}/commits/{branch}"
+    response = requests.get(url, headers=_github_headers(), timeout=10)
+    response.raise_for_status()
+    data = response.json()
+    sha = data.get("sha")
+    if not sha:
+        raise ValueError("GitHub commit response missing sha")
+    return sha
+
+
+def _parse_check_run(payload: Dict[str, Any]) -> CheckRunState:
+    """Convert a GitHub check run payload to :class:`CheckRunState`.
+
+    Args:
+        payload: Raw JSON payload describing a check run.
+
+    Returns:
+        CheckRunState: Parsed check run metadata.
+
+    Raises:
+        KeyError: If the payload lacks an ``id`` field.
+    """
+
+    return CheckRunState(
+        run_id=int(payload["id"]),
+        status=payload.get("status", ""),
+        conclusion=payload.get("conclusion"),
+        html_url=payload.get("html_url"),
+    )
+
+
+def fetch_deepsource_check_run(commit_sha: str) -> Optional[CheckRunState]:
+    """Return the DeepSource check run for ``commit_sha`` if present.
+
+    Args:
+        commit_sha: Commit hash to inspect.
+
+    Returns:
+        Optional[CheckRunState]: The parsed DeepSource check run or ``None``
+        when no matching run is attached to the commit.
+
+    Raises:
+        requests.HTTPError: If GitHub returns an error response.
+    """
+
+    url = (
+        f"https://api.github.com/repos/{GITHUB_REPO}/commits/{commit_sha}/check-runs"
+    )
+    headers = _github_headers()
+    response = requests.get(url, headers=headers, timeout=10)
+    response.raise_for_status()
+    payload = response.json()
+    for run in payload.get("check_runs", []):
+        app = run.get("app", {})
+        if app.get("name") == DEEPSOURCE_APP_NAME:
+            return _parse_check_run(run)
+    return None
+
+
+def build_snapshot(commit_sha: str) -> MonitorSnapshot:
+    """Return the DeepSource status snapshot for ``commit_sha``.
+
+    Args:
+        commit_sha: Target commit hash.
+
+    Returns:
+        MonitorSnapshot: Snapshot containing the commit hash and DeepSource
+        check run (if present).
+    """
+
+    check_run = fetch_deepsource_check_run(commit_sha)
+    return MonitorSnapshot(commit_sha=commit_sha, check_run=check_run)
+
+
+def should_notify(previous: Optional[MonitorSnapshot], current: MonitorSnapshot) -> bool:
+    """Return ``True`` when ``current`` represents a new or changed status.
+
+    Args:
+        previous: Prior snapshot or ``None`` if this is the first sample.
+        current: Newly fetched snapshot.
+
+    Returns:
+        bool: ``True`` when a notification should be emitted.
+    """
+
+    if previous is None:
+        return True
+    if previous.commit_sha != current.commit_sha:
+        return True
+    prev_run = previous.check_run
+    curr_run = current.check_run
+    if prev_run is None or curr_run is None:
+        return (prev_run is None) != (curr_run is None)
+    return (
+        prev_run.run_id != curr_run.run_id
+        or prev_run.status != curr_run.status
+        or (prev_run.conclusion or "").lower()
+        != (curr_run.conclusion or "").lower()
+    )
+
+
+def format_status_message(snapshot: MonitorSnapshot) -> str:
+    """Return a human-readable status message for ``snapshot``.
+
+    Args:
+        snapshot: Snapshot to describe.
+
+    Returns:
+        str: Rendered status message summarizing the DeepSource check.
+    """
+
+    short_sha = snapshot.commit_sha[:7]
+    run = snapshot.check_run
+    if run is None:
+        return f"No DeepSource check run found for commit {short_sha}."
+
+    status = (run.status or "unknown").lower()
+    if status == "completed":
+        conclusion = (run.conclusion or "unknown").lower()
+        message = f"DeepSource check completed ({conclusion}) on commit {short_sha}"
+    else:
+        message = f"DeepSource check {status} on commit {short_sha}"
+    if run.html_url:
+        message += f" – {run.html_url}"
+    return message
+
+
+def log_snapshot(snapshot: MonitorSnapshot) -> None:
+    """Log ``snapshot`` with an appropriate severity level.
+
+    Args:
+        snapshot: Snapshot describing the current DeepSource status.
+    """
+
+    run = snapshot.check_run
+    message = format_status_message(snapshot)
+    if run is None:
+        logger.warning(message)
+    elif run.is_failure:
+        logger.error(message)
+    else:
+        logger.info(message)
+
+
+def monitor_deepsource(poll_interval: int = POLL_INTERVAL) -> None:
+    """Continuously monitor the DeepSource GitHub check run.
+
+    Args:
+        poll_interval: Number of seconds to wait between polls.
+    """
+
+    previous: Optional[MonitorSnapshot] = None
+    while True:
+        try:
+            branch = fetch_default_branch()
+            commit_sha = fetch_latest_commit_sha(branch)
+            snapshot = build_snapshot(commit_sha)
+            if should_notify(previous, snapshot):
+                log_snapshot(snapshot)
+            previous = snapshot
+        except (requests.HTTPError, ValueError) as exc:
+            logger.error("GitHub API error: %s", exc)
+        except requests.RequestException as exc:
+            logger.error("Network error contacting GitHub: %s", exc)
+        time.sleep(poll_interval)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    monitor_deepsource()

--- a/unittests/deepsource_monitor_test.py
+++ b/unittests/deepsource_monitor_test.py
@@ -1,0 +1,116 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import deepsource_monitor as dm
+
+
+def test_check_run_state_is_failure():
+    failing = dm.CheckRunState(
+        run_id=1, status="completed", conclusion="failure", html_url=None
+    )
+    assert failing.is_failure
+
+    success = dm.CheckRunState(
+        run_id=2, status="completed", conclusion="success", html_url=None
+    )
+    assert not success.is_failure
+
+    pending = dm.CheckRunState(run_id=3, status="queued", conclusion=None, html_url=None)
+    assert not pending.is_failure
+
+
+def test_should_notify_changes():
+    previous = dm.MonitorSnapshot(commit_sha="abcdef0", check_run=None)
+    current_same = dm.MonitorSnapshot(commit_sha="abcdef0", check_run=None)
+    assert not dm.should_notify(previous, current_same)
+
+    new_commit = dm.MonitorSnapshot(commit_sha="1234567", check_run=None)
+    assert dm.should_notify(previous, new_commit)
+
+    previous_run = dm.MonitorSnapshot(
+        commit_sha="abcdef0",
+        check_run=dm.CheckRunState(1, "queued", None, None),
+    )
+    completed_run = dm.MonitorSnapshot(
+        commit_sha="abcdef0",
+        check_run=dm.CheckRunState(1, "completed", "success", None),
+    )
+    assert dm.should_notify(previous_run, completed_run)
+
+
+def test_format_status_message_includes_context():
+    snapshot = dm.MonitorSnapshot(commit_sha="abcdef012345", check_run=None)
+    assert "abcdef0" in dm.format_status_message(snapshot)
+
+    run = dm.CheckRunState(
+        run_id=99,
+        status="completed",
+        conclusion="failure",
+        html_url="https://example.com/check",
+    )
+    snapshot = dm.MonitorSnapshot(commit_sha="1234567890", check_run=run)
+    message = dm.format_status_message(snapshot)
+    assert "failure" in message
+    assert "1234567" in message
+    assert "https://example.com/check" in message
+
+
+def test_fetch_deepsource_check_run(monkeypatch):
+    captured = {}
+
+    class FakeResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "check_runs": [
+                    {
+                        "id": 2,
+                        "status": "completed",
+                        "conclusion": "failure",
+                        "html_url": "https://example.com/failure",
+                        "app": {"name": dm.DEEPSOURCE_APP_NAME},
+                    }
+                ]
+            }
+
+    def fake_get(url, headers, timeout):
+        captured["url"] = url
+        captured["headers"] = headers
+        return FakeResp()
+
+    monkeypatch.setattr(dm.requests, "get", fake_get)
+
+    result = dm.fetch_deepsource_check_run("abc123")
+    assert result is not None
+    assert result.run_id == 2
+    assert captured["url"].endswith("/commits/abc123/check-runs")
+    assert "Authorization" in captured["headers"] or dm.GITHUB_TOKEN == ""
+
+
+def test_fetch_default_branch(monkeypatch):
+    class FakeResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"default_branch": "main"}
+
+    monkeypatch.setattr(dm.requests, "get", lambda *a, **k: FakeResp())
+    assert dm.fetch_default_branch() == "main"
+
+
+def test_fetch_latest_commit_sha(monkeypatch):
+    class FakeResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"sha": "abcdef123"}
+
+    monkeypatch.setattr(dm.requests, "get", lambda *a, **k: FakeResp())
+    assert dm.fetch_latest_commit_sha("main") == "abcdef123"


### PR DESCRIPTION
## Summary
- add a DeepSource GitHub check monitor script that logs status changes
- cover the monitor helpers and GitHub fetchers with unit tests
- document monitor usage and configuration in the README

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68d37c052d6c8329b7e23bb3126c6480