### PR TITLE
Resolve conflicts with tertiary channel and ignore broker updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,21 @@ The bot's `..all` command now audits your holdings against the watchlist,
 summarizes any tickers that are missing from your accounts, and consolidates
 broker holdings status into a single embed.
 
+### Discord channel configuration
+
+RSAssistant differentiates between three Discord channels so information lands
+where it is most actionable:
+
+- `DISCORD_PRIMARY_CHANNEL`: Operational commands, holdings refresh output, and
+  scheduled order confirmations.
+- `DISCORD_SECONDARY_CHANNEL`: Source feed where NASDAQ and SEC alerts arrive.
+- `DISCORD_TERTIARY_CHANNEL`: Destination for reverse split summaries and the
+  associated policy snippets parsed from filings or press releases.
+
+Populate the corresponding environment variables in your `.env` file with the
+channel IDs for your server. When the tertiary channel ID is omitted, the bot
+falls back to the primary channel to avoid dropping critical alerts.
+
 ### Configuration: Auto Refresh + Monitor
 
 Add the following keys to your environment. The app now loads from a single source:
@@ -106,6 +121,8 @@ Add the following keys to your environment. The app now loads from a single sour
 - `AUTO_SELL_LIVE` (bool): If `true`, also post `..ord sell {ticker} {broker} {quantity}`. Default `false`.
 - `IGNORE_TICKERS` (CSV): Tickers to skip for alert/auto-sell (e.g., `ABCD,EFGH`). Default empty.
 - `IGNORE_TICKERS_FILE` (path, optional): File containing one ticker per line to ignore. Defaults to `volumes/config/ignore_tickers.txt`. Lines starting with `#` are treated as comments.
+- `IGNORE_BROKERS` (CSV): Brokers to skip for alert/auto-sell (e.g., `Fidelity,Schwab`). Default empty.
+- `IGNORE_BROKERS_FILE` (path, optional): File containing one broker name per line to ignore. Defaults to `volumes/config/ignore_brokers.txt`. Lines starting with `#` are treated as comments.
 
 You can use either the env var, the file, or both — the sets merge. Create the file like:
 
@@ -114,6 +131,9 @@ cp config/ignore_tickers.example.txt volumes/config/ignore_tickers.txt
 echo "AAPL" >> volumes/config/ignore_tickers.txt
 echo "MSFT  # Long-term" >> volumes/config/ignore_tickers.txt
 ```
+
+Apply the same approach for brokers by creating `volumes/config/ignore_brokers.txt`
+with one broker name per line.
 
 - `MENTION_USER_ID` (string): Your Discord user ID to @-mention in alerts (e.g., `123456789012345678`). Optional.
 - `MENTION_ON_ALERTS` (bool): Enable/disable mentions on alerts. Default `true`.

--- a/config/example.env
+++ b/config/example.env
@@ -4,7 +4,7 @@ BOT_TOKEN=
 DISCORD_PRIMARY_CHANNEL=
 # -- Nasdaq Corporate Actions RSS Feed
 DISCORD_SECONDARY_CHANNEL=
-# -- I forget what I have this channel defined for
+# -- Reverse split summaries + snippets destination
 DISCORD_TERTIARY_CHANNEL=
 
 # Optional path to the persistent data directory. Defaults to
@@ -24,6 +24,12 @@ HOLDING_ALERT_MIN_PRICE=1
 AUTO_SELL_LIVE=false
 # Comma-separated tickers to ignore for alert/auto-sell (e.g., ABCD,EFGH)
 IGNORE_TICKERS=
+# Optional override for ticker ignore list path (defaults to volumes/config/ignore_tickers.txt)
+IGNORE_TICKERS_FILE=
+# Comma-separated brokers to ignore for alert/auto-sell (e.g., Fidelity,Schwab)
+IGNORE_BROKERS=
+# Optional override for broker ignore list path (defaults to volumes/config/ignore_brokers.txt)
+IGNORE_BROKERS_FILE=
 
 # --- Mentions ---
 # Set your Discord user ID to @-mention you in alerts (e.g., 123456789012345678)

--- a/unittests/config_utils_test.py
+++ b/unittests/config_utils_test.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 
 from utils import config_utils
 
@@ -35,6 +34,23 @@ def test_ignore_tickers_file_and_env_merge(tmp_path, monkeypatch):
     merged = config_utils._compute_ignore_tickers()
     # Uppercased unique set from both sources
     assert merged == {"AAPL", "MSFT", "GOOG", "AMZN"}
+
+
+def test_ignore_brokers_file_and_env_merge(tmp_path, monkeypatch):
+    ignore_file = tmp_path / "ignore_brokers.txt"
+    ignore_file.write_text("""
+    Fidelity
+    Schwab  # Workplace plan
+
+
+    """.strip(), encoding="utf-8")
+
+    monkeypatch.setattr(config_utils, "IGNORE_BROKERS_FILE", ignore_file)
+    monkeypatch.setenv("IGNORE_BROKERS", "tasty, , robinhood ")
+
+    merged = config_utils._compute_ignore_brokers()
+
+    assert merged == {"FIDELITY", "SCHWAB", "TASTY", "ROBINHOOD"}
 
 
 def test_persistence_defaults_true():

--- a/unittests/on_message_utils_test.py
+++ b/unittests/on_message_utils_test.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from utils.on_message_utils import compute_account_missing_tickers
+from utils import on_message_utils
 from utils.watch_utils import watch_list_manager
 
 
@@ -18,8 +18,21 @@ def test_compute_account_missing_tickers(monkeypatch):
         {"broker": "Test", "account_name": "Nick1", "account": "1111", "ticker": "CCC"},
         {"broker": "Test", "account_name": "Nick2", "account": "2222", "ticker": "BBB"},
     ]
-    result = compute_account_missing_tickers(holdings)
+    result = on_message_utils.compute_account_missing_tickers(holdings)
     assert result == {
         "Test Nick1 (1111)": ["BBB"],
         "Test Nick2 (2222)": ["AAA"],
     }
+
+
+def test_is_broker_ignored(monkeypatch):
+    monkeypatch.setattr(
+        on_message_utils,
+        "IGNORE_BROKERS_SET",
+        {"TASTYWORKS", "TD AMERITRADE"},
+    )
+
+    assert on_message_utils.is_broker_ignored("tastyworks") is True
+    assert on_message_utils.is_broker_ignored("  td ameritrade  ") is True
+    assert on_message_utils.is_broker_ignored("Fidelity") is False
+    assert on_message_utils.is_broker_ignored("") is False


### PR DESCRIPTION
## Summary
- merge main commit 5baabd7a3e961899da0315ae7917b58c108926e4 into the holdings-summary branch
- retain documentation and example env updates that describe tertiary channel routing and broker ignore lists
- keep config/on_message utilities aligned so ignored brokers are filtered and reverse split messages can fall back across channels
- restore missing imports in config and on-message unit tests to validate the new helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca313354b88329ba94373259d5a128