### PR TITLE
Adjust watchlist commands to separate price display options

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Any value other than `false` leaves the logger enabled.
 
 RSAssistant can optionally trigger a holdings refresh when a watchlist reminder is posted, then watch incoming holdings embeds and alert on positions meeting a price threshold. It can also optionally auto-sell those positions.
 
+### Watchlist commands
+
+- `..watchlist`: Display all tracked tickers with their split dates and ratios (no prices).
+- `..watchprices`: Display the watchlist with split info and the latest pulled prices.
+- `..prices`: List only the latest prices for tickers on the watchlist.
+
 - Auto refresh on reminder: posts `!rsa holdings all` after the reminder
 - Over-threshold alert: posts a note in the primary Discord channel
 - Optional auto-sell: posts a `..ord sell {ticker} {broker} {quantity}`

--- a/RSAssistant.py
+++ b/RSAssistant.py
@@ -739,8 +739,28 @@ async def add_ratio(ctx, ticker: str, split_ratio: str):
     extras={"category": "Watchlist"},
 )
 async def allwatching(ctx):
-    """Lists all tickers being watched."""
-    await watch_list_manager.list_watched_tickers(ctx)
+    """List watched tickers with split dates and ratios."""
+    await watch_list_manager.list_watched_tickers(ctx, include_prices=False)
+
+
+@bot.command(
+    name="watchprices",
+    help="List watched tickers with split info and latest prices.",
+    extras={"category": "Watchlist"},
+)
+async def watchlist_with_prices(ctx):
+    """List watched tickers including their latest price."""
+    await watch_list_manager.list_watched_tickers(ctx, include_prices=True)
+
+
+@bot.command(
+    name="prices",
+    help="Show the latest price for each watchlist ticker.",
+    extras={"category": "Watchlist"},
+)
+async def watchlist_prices(ctx):
+    """Display only the latest prices for watchlist tickers."""
+    await watch_list_manager.send_watchlist_prices(ctx)
 
 
 @bot.command(


### PR DESCRIPTION
## Summary
- default `..watchlist` to show tickers with split dates and ratios only
- add `..watchprices` and `..prices` commands for optional price output
- cover watch list presentation helpers with unit tests and README updates

## Testing
- python -m unittest discover -s unittests -p '*_test.py'

------
https://chatgpt.com/codex/tasks/task_e_68dcf7d7ebe08329a555a7ffeb9ef894