### PR TITLE
feat: limit tagged alerts to configured tickers

### DIFF
--- a/config/example.env
+++ b/config/example.env
@@ -40,6 +40,13 @@ MENTION_USER_IDS=
 # Enable/disable mention on over-threshold holding alerts
 MENTION_ON_ALERTS=true
 
+# --- Tagged alert filters ---
+# Optional comma-separated list restricting mentions to specific tickers.
+# Format: TICKER or TICKER:MIN_QUANTITY (e.g., AAPL:50,TSLA)
+TAGGED_ALERT_TICKERS=
+# Optional override for tagged alert filter file (defaults to volumes/config/tagged_alerts.txt)
+TAGGED_ALERTS_FILE=
+
 # --- Persistence toggles ---
 # Set to 'false' to disable writing to CSV, Excel, or SQL storage
 CSV_LOGGING_ENABLED=true

--- a/config/tagged_alerts.example.txt
+++ b/config/tagged_alerts.example.txt
@@ -1,0 +1,4 @@
+# One ticker per line. Use optional ':quantity' to require a minimum size.
+# Lines beginning with '#' are ignored.
+AAPL:50
+TSLA

--- a/unittests/tagged_alerts_test.py
+++ b/unittests/tagged_alerts_test.py
@@ -1,0 +1,70 @@
+import importlib
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from utils import config_utils
+from utils import on_message_utils
+
+
+class TaggedAlertConfigTests(unittest.TestCase):
+    """Validate tagged alert configuration parsing from env and files."""
+
+    def test_requirements_from_env_and_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "tagged_alerts.txt"
+            config_path.write_text("AAPL:50\nmsft\n", encoding="utf-8")
+            env_vars = {
+                "TAGGED_ALERT_TICKERS": "TSLA:5, GOOG",
+                "TAGGED_ALERTS_FILE": str(config_path),
+            }
+            try:
+                with mock.patch.dict(os.environ, env_vars, clear=False):
+                    reloaded = importlib.reload(config_utils)
+                    self.assertEqual(
+                        reloaded.TAGGED_ALERT_REQUIREMENTS,
+                        {
+                            "AAPL": 50.0,
+                            "MSFT": None,
+                            "TSLA": 5.0,
+                            "GOOG": None,
+                        },
+                    )
+            finally:
+                importlib.reload(config_utils)
+
+
+class TaggedAlertDecisionTests(unittest.TestCase):
+    """Ensure mention decisions respect tagged alert requirements."""
+
+    def test_should_tag_alerts_based_on_requirements(self):
+        original_requirements = on_message_utils.TAGGED_ALERT_REQUIREMENTS
+        try:
+            on_message_utils.TAGGED_ALERT_REQUIREMENTS = {
+                "AAPL": 10.0,
+                "MSFT": None,
+            }
+            self.assertTrue(on_message_utils._should_tag_alert("AAPL", 10))
+            self.assertTrue(on_message_utils._should_tag_alert("AAPL", 12.5))
+            self.assertFalse(on_message_utils._should_tag_alert("AAPL", 5))
+            self.assertTrue(on_message_utils._should_tag_alert("MSFT", 1))
+            self.assertFalse(on_message_utils._should_tag_alert("TSLA", 100))
+
+            entries = [
+                {"ticker": "AAPL", "quantity": 15},
+                {"ticker": "MSFT", "quantity": 0},
+            ]
+            self.assertTrue(on_message_utils._should_tag_entries(entries))
+
+            limited_entries = [{"ticker": "AAPL", "quantity": 5}]
+            self.assertFalse(on_message_utils._should_tag_entries(limited_entries))
+
+            self.assertFalse(on_message_utils._should_tag_entries([]))
+        finally:
+            on_message_utils.TAGGED_ALERT_REQUIREMENTS = original_requirements
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add configuration helpers for tagged-alert ticker/quantity requirements backed by env values or a config file
- gate holdings alert mentions by the configured tickers and minimum quantities while keeping AREB overrides
- document the new settings and cover the parsing/tagging logic with dedicated unit tests

## Testing
- python -m unittest discover -s unittests -p '*_test.py'


------
https://chatgpt.com/codex/tasks/task_e_68e4113543048329a657ca5dd962c7cf