### PR TITLE
fix(holdings): parse integer/comma-formatted values from broker embeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ RSAssistant is a Discord bot that monitors reverse split announcements and autom
 - Extracts dates, ratios, and fractional share policies from filings.
 - Maintains watch and sell lists, reminders, and scheduled orders.
 - Refreshes holdings via `..all`, audits them against the watchlist, posts consolidated summaries, and can queue watchlist autobuys for missing broker positions.
+- Parses holdings values from broker embeds in integer/decimal/comma formats to keep multi-broker snapshots complete.
 - Persists logs, watchlists, and account mappings in SQLite under `volumes/` (override with `VOLUMES_DIR`).
 
 ## Quickstart (local)

--- a/unittests/parsing_utils_test.py
+++ b/unittests/parsing_utils_test.py
@@ -1,9 +1,14 @@
 """Unit tests for :mod:`utils.parsing_utils`."""
 
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
 
-from utils.parsing_utils import alert_channel_message, parse_order_message
+from utils.parsing_utils import (
+    alert_channel_message,
+    parse_general_embed_message,
+    parse_order_message,
+)
 
 
 class AlertChannelMessageTest(unittest.TestCase):
@@ -97,6 +102,34 @@ class ParseOrderMessageTest(unittest.TestCase):
 
         self.assertEqual(result["ticker"], "SLE")
         self.assertTrue(result["reverse_split_confirmed"])
+
+
+class ParseHoldingsEmbedTest(unittest.TestCase):
+    """Validate holdings extraction from broker embed content."""
+
+    @staticmethod
+    def _build_embed(field_name: str, field_value: str):
+        return SimpleNamespace(
+            fields=[SimpleNamespace(name=field_name, value=field_value)]
+        )
+
+    def test_general_embed_parses_integer_and_comma_values(self) -> None:
+        embed = self._build_embed(
+            "Schwab 1 xxxxx1234",
+            "ABC: 5 @ $10 = $50\nXYZ: 1,250 @ $2.50 = $3,125\nTotal: $3,175",
+        )
+
+        holdings = parse_general_embed_message(embed)
+
+        self.assertEqual(len(holdings), 2)
+        self.assertEqual(holdings[0]["ticker"], "ABC")
+        self.assertEqual(holdings[0]["quantity"], "5")
+        self.assertEqual(holdings[0]["price"], "10")
+        self.assertEqual(holdings[1]["ticker"], "XYZ")
+        self.assertEqual(holdings[1]["quantity"], "1250")
+        self.assertEqual(holdings[1]["price"], "2.50")
+        self.assertEqual(holdings[1]["value"], "3125")
+        self.assertEqual(holdings[1]["account_total"], "3,175")
 
 
 if __name__ == "__main__":

--- a/utils/parsing_utils.py
+++ b/utils/parsing_utils.py
@@ -87,6 +87,16 @@ _ALERT_TICKER_PATTERNS = [
     re.compile(r"\(([A-Za-z][A-Za-z0-9]{0,9})\)"),
 ]
 
+_HOLDINGS_LINE_PATTERN = re.compile(
+    r"([\w\s]+):\s*([-+]?\d[\d,]*(?:\.\d+)?)\s*@\s*\$([-+]?\d[\d,]*(?:\.\d+)?)\s*=\s*\$([-+]?\d[\d,]*(?:\.\d+)?)"
+)
+
+
+def _normalize_numeric_capture(raw_value: str) -> str:
+    """Normalize parsed numeric text for downstream float coercion."""
+
+    return str(raw_value).replace(",", "").strip()
+
 
 def _normalize_ticker_symbol(raw_ticker: Optional[str]) -> Optional[str]:
     """Normalize ticker candidates extracted from alert text or remote sources.
@@ -904,14 +914,12 @@ def parse_general_embed_message(embed):
         for line in value_field.splitlines():
             if "No holdings in Account" in line:
                 continue
-            match = re.match(
-                r"([\w\s]+): (\d+\.\d+) @ \$(\d+\.\d+) = \$(\d+\.\d+)", line
-            )
+            match = _HOLDINGS_LINE_PATTERN.match(line)
             if match:
                 stock = match.group(1).strip()
-                quantity = match.group(2)
-                price = match.group(3)
-                total_value = match.group(4)
+                quantity = _normalize_numeric_capture(match.group(2))
+                price = _normalize_numeric_capture(match.group(3))
+                total_value = _normalize_numeric_capture(match.group(4))
                 new_holdings.append(
                     {
                         "account_name": account_name,
@@ -981,14 +989,12 @@ def parse_webull_embed_message(embed):
         for line in value_field.splitlines():
             if "No holdings in Account" in line:
                 continue
-            match = re.match(
-                r"([\w\s]+): (\d+\.\d+) @ \$(\d+\.\d+) = \$(\d+\.\d+)", line
-            )
+            match = _HOLDINGS_LINE_PATTERN.match(line)
             if match:
                 stock = match.group(1).strip()
-                quantity = match.group(2)
-                price = match.group(3)
-                total_value = match.group(4)
+                quantity = _normalize_numeric_capture(match.group(2))
+                price = _normalize_numeric_capture(match.group(3))
+                total_value = _normalize_numeric_capture(match.group(4))
                 new_holdings.append(
                     {
                         "account_name": account_name,
@@ -1045,14 +1051,12 @@ def parse_fennel_embed_message(embed):
             for line in value_field.splitlines():
                 if "No holdings in Account" in line:
                     continue
-                match = re.match(
-                    r"([\w\s]+): ([\-\d\.]+) @ \$(\d+\.\d+) = \$(\-?\d+\.\d+)", line
-                )
+                match = _HOLDINGS_LINE_PATTERN.match(line)
                 if match:
                     stock = match.group(1).strip()
-                    quantity = match.group(2)
-                    price = match.group(3)
-                    total_value = match.group(4)
+                    quantity = _normalize_numeric_capture(match.group(2))
+                    price = _normalize_numeric_capture(match.group(3))
+                    total_value = _normalize_numeric_capture(match.group(4))
                     new_holdings.append(
                         {
                             "account_name": account_key,


### PR DESCRIPTION
### Motivation
- Broker embed lines outside Fidelity often use integer, comma-formatted, or non-decimal numeric tokens that the previous strict parser rejected, causing snapshots to only include Fidelity holdings.
- The intent is to ensure holdings from all brokers are parsed and preserved so `..snapshot` shows a complete multi-broker view.

### Description
- Added a shared holdings-line regex `_HOLDINGS_LINE_PATTERN` to accept integer, decimal, signed, and comma-formatted numeric values and replaced the brittle per-parser regexes in `parse_general_embed_message`, `parse_webull_embed_message`, and `parse_fennel_embed_message` with it (`utils/parsing_utils.py`).
- Added `_normalize_numeric_capture` to remove thousands separators (commas) and trim numeric captures before downstream float coercion (`utils/parsing_utils.py`).
- Added a regression unit test that builds a synthetic embed with integer and comma-formatted values and asserts both rows parse (`unittests/parsing_utils_test.py`).
- Updated `README.md` to note that holdings parsing now accepts integer/decimal/comma formats so multi-broker snapshots remain complete.

### Testing
- Ran the focused test file with `python -m unittest unittests/parsing_utils_test.py` and it passed (`OK`).
- Ran a compile check with `python -m compileall utils/parsing_utils.py unittests/parsing_utils_test.py` and it succeeded.
- Ran the full suite with `python -m unittest discover -s unittests -p '*_test.py'`; the new parser change did not introduce failures, but the run still shows pre-existing unrelated test issues that block a green suite: missing `RSAssistant.on_command_error`, missing `RSAssistant.ORD_COMMAND_USAGE`, `ModuleNotFoundError: No module named 'matplotlib'` when importing history plotting, and one existing assertion failure in `order_queue_tasks_test`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9ba1b26a08329b018c8b530312e14)