### PR TITLE
feat(env-gui): add Codex Change Request panel and backend submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ python scripts/env_gui.py
 
 Then open `http://127.0.0.1:8765` in your browser.
 
+The GUI includes a **Codex Change Request** panel where operators can choose a request type, enter implementation instructions, and submit them to `codex exec` from the same page.
+
 ## Policy parsing flow
 
 1. Programmatic parsing (NASDAQ/SEC/press release) runs when `PROGRAMMATIC_POLICY_ENABLED=true`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,6 +25,10 @@ All runtime state lives under `VOLUMES_DIR` (default `./volumes`):
 - `logs/` (application logs + CSV exports such as holdings/orders)
 - `excel/` (legacy archive only; no runtime writes)
 
+## Local operations UI
+
+`scripts/env_gui.py` provides a local-only web UI for editing `config/.env` and now includes a Codex request panel that can invoke `codex exec` with operator-entered change instructions.
+
 ## Auto-rsa integration
 
 RSAssistant does not import auto-rsa code. It communicates via Discord commands

--- a/scripts/env_gui.py
+++ b/scripts/env_gui.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
@@ -14,6 +15,7 @@ BASE_DIR = Path(__file__).resolve().parents[1]
 CONFIG_DIR = BASE_DIR / "config"
 ENV_PATH = CONFIG_DIR / ".env"
 TEMPLATE_PATH = CONFIG_DIR / ".env.example"
+CODEX_PROMPT_LIMIT = 4000
 
 
 def _parse_env_lines(lines: list[str]) -> list[dict[str, Any]]:
@@ -290,6 +292,26 @@ def _build_html(entries: list[dict[str, Any]]) -> str:
       color: var(--muted);
       font-size: 13px;
     }
+    .codex-section {
+      margin-top: 32px;
+      border-top: 1px solid var(--stroke);
+      padding-top: 24px;
+    }
+    .codex-field {
+      margin-top: 14px;
+    }
+    .codex-field textarea {
+      width: 100%;
+      min-height: 130px;
+      padding: 12px;
+      border-radius: 10px;
+      border: 1px solid var(--stroke);
+      font-family: "Fira Mono", "Cascadia Mono", "Courier New", monospace;
+      font-size: 14px;
+      background: rgba(255,255,255,0.04);
+      color: var(--ink);
+      resize: vertical;
+    }
     @keyframes fadeIn {
       from { opacity: 0; transform: translateY(8px); }
       to { opacity: 1; transform: translateY(0); }
@@ -312,6 +334,27 @@ def _build_html(entries: list[dict[str, Any]]) -> str:
         <button id="saveBtn">Save .env</button>
         <span id="status" class="status"></span>
       </div>
+      <section class="codex-section" aria-labelledby="codexTitle">
+        <h2 id="codexTitle">Codex Change Request</h2>
+        <p class="status">Describe a feature request or change and run Codex CLI from this page.</p>
+        <div class="codex-field">
+          <label for="changeType">Request Type</label>
+          <select id="changeType">
+            <option value="feature">Feature</option>
+            <option value="bugfix">Bug Fix</option>
+            <option value="refactor">Refactor</option>
+            <option value="docs">Documentation</option>
+          </select>
+        </div>
+        <div class="codex-field">
+          <label for="changeRequest">Change Details</label>
+          <textarea id="changeRequest" placeholder="Describe exactly what Codex should build or update."></textarea>
+        </div>
+        <div class="actions">
+          <button id="submitChangeBtn">Submit to Codex CLI</button>
+          <span id="codexStatus" class="status"></span>
+        </div>
+      </section>
     </div>
   </main>
   <script>
@@ -319,6 +362,7 @@ def _build_html(entries: list[dict[str, Any]]) -> str:
     const container = document.getElementById('fields');
     const status = document.getElementById('status');
     const themeSelect = document.getElementById('themeSelect');
+    const codexStatus = document.getElementById('codexStatus');
     const themes = [
       { id: 'nightfox', label: 'Nightfox' },
       { id: 'rose-pine', label: 'Rose Pine' },
@@ -382,6 +426,23 @@ def _build_html(entries: list[dict[str, Any]]) -> str:
       const result = await response.json();
       status.textContent = result.message;
     });
+
+    document.getElementById('submitChangeBtn').addEventListener('click', async () => {
+      const requestText = document.getElementById('changeRequest').value.trim();
+      const requestType = document.getElementById('changeType').value;
+      if (!requestText) {
+        codexStatus.textContent = 'Please add change details before submitting.';
+        return;
+      }
+      codexStatus.textContent = 'Submitting to Codex CLI...';
+      const response = await fetch('/codex-change', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({request_type: requestType, request_text: requestText}),
+      });
+      const result = await response.json();
+      codexStatus.textContent = result.message;
+    });
   </script>
 </body>
  </html>"""
@@ -404,7 +465,8 @@ class EnvGuiHandler(BaseHTTPRequestHandler):
         self._send(HTTPStatus.OK, html)
 
     def do_POST(self) -> None:  # noqa: N802
-        if urlparse(self.path).path != "/save":
+        route = urlparse(self.path).path
+        if route not in {"/save", "/codex-change"}:
             self._send(HTTPStatus.NOT_FOUND, "Not found", "text/plain")
             return
         content_length = int(self.headers.get("Content-Length", "0"))
@@ -419,18 +481,85 @@ class EnvGuiHandler(BaseHTTPRequestHandler):
             )
             return
 
-        entries = _load_example_entries()
-        env_values = _load_env_map(ENV_PATH)
-        example_keys = {
-            entry["key"] for entry in entries if entry.get("type") == "kv"
-        }
-        extras = {key: value for key, value in env_values.items() if key not in example_keys}
-        _write_entries(entries, updates, extras)
+        if route == "/save":
+            entries = _load_example_entries()
+            env_values = _load_env_map(ENV_PATH)
+            example_keys = {
+                entry["key"] for entry in entries if entry.get("type") == "kv"
+            }
+            extras = {
+                key: value
+                for key, value in env_values.items()
+                if key not in example_keys
+            }
+            _write_entries(entries, updates, extras)
+            self._send(
+                HTTPStatus.OK,
+                json.dumps({"message": "Saved config/.env successfully."}),
+                "application/json",
+            )
+            return
+
+        request_type = str(updates.get("request_type", "")).strip().lower()
+        request_text = str(updates.get("request_text", "")).strip()
+        result = submit_codex_change_request(request_type, request_text)
         self._send(
-            HTTPStatus.OK,
-            json.dumps({"message": "Saved config/.env successfully."}),
+            result["status"],
+            json.dumps({"message": result["message"]}),
             "application/json",
         )
+
+
+def submit_codex_change_request(request_type: str, request_text: str) -> dict[str, Any]:
+    """Submit a change request through Codex CLI.
+
+    Args:
+        request_type: The selected request category from the GUI.
+        request_text: The free-form change description entered by the operator.
+
+    Returns:
+        A dictionary containing an HTTP status code and user-facing message.
+    """
+    if not request_text:
+        return {
+            "status": HTTPStatus.BAD_REQUEST,
+            "message": "Change details are required.",
+        }
+    if len(request_text) > CODEX_PROMPT_LIMIT:
+        return {
+            "status": HTTPStatus.BAD_REQUEST,
+            "message": f"Change details exceed {CODEX_PROMPT_LIMIT} characters.",
+        }
+
+    prompt = (
+        f"Request type: {request_type or 'general'}\\n"
+        "Implement the following change in the current repository:\\n"
+        f"{request_text}"
+    )
+    try:
+        completed = subprocess.run(
+            ["codex", "exec", prompt],
+            cwd=BASE_DIR,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as exc:
+        return {
+            "status": HTTPStatus.INTERNAL_SERVER_ERROR,
+            "message": f"Unable to run Codex CLI: {exc}",
+        }
+
+    if completed.returncode != 0:
+        stderr = completed.stderr.strip() or "Codex CLI returned a non-zero exit code."
+        return {
+            "status": HTTPStatus.INTERNAL_SERVER_ERROR,
+            "message": f"Codex request failed: {stderr}",
+        }
+    return {
+        "status": HTTPStatus.OK,
+        "message": "Codex CLI request submitted successfully.",
+    }
 
 
 def main() -> None:

--- a/unittests/env_gui_test.py
+++ b/unittests/env_gui_test.py
@@ -1,0 +1,44 @@
+import unittest
+from http import HTTPStatus
+from unittest.mock import Mock, patch
+
+from scripts import env_gui
+
+
+class SubmitCodexChangeRequestTest(unittest.TestCase):
+    def test_rejects_empty_change_details(self) -> None:
+        result = env_gui.submit_codex_change_request("feature", "")
+
+        self.assertEqual(result["status"], HTTPStatus.BAD_REQUEST)
+        self.assertIn("required", result["message"])
+
+    def test_rejects_oversized_change_details(self) -> None:
+        oversized = "x" * (env_gui.CODEX_PROMPT_LIMIT + 1)
+
+        result = env_gui.submit_codex_change_request("feature", oversized)
+
+        self.assertEqual(result["status"], HTTPStatus.BAD_REQUEST)
+        self.assertIn(str(env_gui.CODEX_PROMPT_LIMIT), result["message"])
+
+    @patch("scripts.env_gui.subprocess.run")
+    def test_returns_success_on_zero_exit(self, run_mock: Mock) -> None:
+        run_mock.return_value = Mock(returncode=0, stderr="")
+
+        result = env_gui.submit_codex_change_request("bugfix", "Fix the crash")
+
+        self.assertEqual(result["status"], HTTPStatus.OK)
+        self.assertIn("successfully", result["message"])
+        run_mock.assert_called_once()
+
+    @patch("scripts.env_gui.subprocess.run")
+    def test_returns_error_on_non_zero_exit(self, run_mock: Mock) -> None:
+        run_mock.return_value = Mock(returncode=1, stderr="failed")
+
+        result = env_gui.submit_codex_change_request("docs", "Update docs")
+
+        self.assertEqual(result["status"], HTTPStatus.INTERNAL_SERVER_ERROR)
+        self.assertIn("failed", result["message"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a local UI for operators to type a labeled change request (with a dropdown for request type) and submit it to the Codex CLI so small repo changes/feature requests can be initiated from the env GUI.
- Keep the new UI visually consistent with the existing themed card layout and make submission robust with validation and error handling.

### Description
- Added a `Codex Change Request` section to `scripts/env_gui.py` with a `Request Type` dropdown and a labeled multiline `Change Details` textarea that matches the existing theme/UX and layout.
- Implemented a backend POST route `/codex-change` inside `scripts/env_gui.py` and a helper `submit_codex_change_request()` that validates input, enforces `CODEX_PROMPT_LIMIT`, and invokes the CLI via `subprocess.run(["codex", "exec", prompt], cwd=BASE_DIR, ...)` with error handling and clear status messages.
- Preserved the previous `.env` save behavior and wired the frontend Submit button to POST JSON to `/codex-change` and surface response messages in the UI.
- Updated docs (`README.md`, `docs/architecture.md`) to mention the new GUI Codex panel and added unit tests in `unittests/env_gui_test.py` covering empty input, oversized input, success (mocked subprocess), and non-zero CLI exit cases.

### Testing
- Ran code formatting with `black scripts/env_gui.py unittests/env_gui_test.py` which succeeded and reformatted the modified file.
- Executed the new unit tests with `python -m unittest unittests/env_gui_test.py` and they all passed.
- Ran the full test suite with `python -m unittest discover -s unittests -p '*_test.py'` and it still fails for unrelated pre-existing issues: missing `matplotlib` in `holdings_cog_test`, missing expected symbols in the `RSAssistant` module referenced by command tests, and one assertion failure in `order_queue_tasks_test`; these failures are not caused by the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03d9dc3d188329a6fda386ed73bf15)